### PR TITLE
test: use AutoFixture to improve setup in unit test

### DIFF
--- a/Test/AutoMoqDataAttribute.cs
+++ b/Test/AutoMoqDataAttribute.cs
@@ -1,0 +1,18 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Xunit2;
+
+namespace Test
+{
+
+	public class AutoMoqDataAttribute : AutoDataAttribute
+	{
+
+		public AutoMoqDataAttribute()
+			: base(() => new Fixture().Customize(new AutoMoqCustomization()))
+		{
+		}
+
+	}
+
+}

--- a/Test/AutoMoqStreamServiceWithNameAndCountAttribute.cs
+++ b/Test/AutoMoqStreamServiceWithNameAndCountAttribute.cs
@@ -1,0 +1,21 @@
+﻿using AutoFixture;
+using AutoFixture.AutoMoq;
+using AutoFixture.Xunit2;
+
+namespace Test
+{
+
+	public class AutoMoqStreamServiceWithNameAndCountAttribute : AutoDataAttribute
+	{
+
+		public AutoMoqStreamServiceWithNameAndCountAttribute()
+			: base(() => new Fixture().Customize(
+				new CompositeCustomization(
+					new AutoMoqStreamServiceWithNameAndCountCustomization(),
+					new AutoMoqCustomization())))
+		{
+		}
+
+	}
+
+}

--- a/Test/AutoMoqStreamServiceWithNameAndCountCustomization.cs
+++ b/Test/AutoMoqStreamServiceWithNameAndCountCustomization.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using AutoFixture;
+using AutoFixture.Kernel;
+using Fritz.StreamTools.Services;
+using Moq;
+
+namespace Test
+{
+
+	public class AutoMoqStreamServiceWithNameAndCountCustomization : ICustomization
+	{
+
+		public void Customize(IFixture fixture)
+		{
+
+			fixture.Customizations.Add(new SpecimenBuilder());
+
+		}
+
+		private class SpecimenBuilder : ISpecimenBuilder
+		{
+
+			public object Create(object request, ISpecimenContext context)
+			{
+
+				var type = request as Type;
+
+				if (type == null || type != typeof(IStreamService))
+				{
+					return new NoSpecimen();
+				}
+
+				var fixture = new Fixture();
+				var mock = new Mock<IStreamService>();
+				mock.SetupGet(s => s.CurrentFollowerCount).Returns(fixture.Create<int>());
+				mock.SetupGet(s => s.CurrentViewerCount).Returns(fixture.Create<int>());
+				mock.SetupGet(s => s.Name).Returns(fixture.Create<string>());
+
+				return mock.Object;
+
+			}
+
+		}
+
+	}
+
+}

--- a/Test/Services/StreamService/FollowerCountByService.cs
+++ b/Test/Services/StreamService/FollowerCountByService.cs
@@ -1,41 +1,30 @@
 ﻿using Fritz.StreamTools.Services;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Linq;
 using Xunit;
 
 namespace Test.Services.StreamService
 {
 
-	public class FollowerCountByService : BaseFixture
+	public class FollowerCountByService
 	{
 
-		[Fact]
-		public void ShouldCountSeparately() {
+		[Theory]
+		[AutoMoqStreamServiceWithNameAndCount]
+		public void ShouldCountSeparately(IStreamService jeffStreams, IStreamService otherStreamService)
+		{
 
 			// arrange
-			var jeffStreams = Mockery.Create<IStreamService>();
-			var jeffsFollowers = new Random().Next(10, 100);
-			jeffStreams.SetupGet(j => j.CurrentFollowerCount).Returns(jeffsFollowers);
-			jeffStreams.SetupGet(j => j.Name).Returns("Jeff");
-
-			var otherStreamService = Mockery.Create<IStreamService>();
-			var otherFollowers = new Random().Next(10, 100);
-			otherStreamService.SetupGet(j => j.CurrentFollowerCount).Returns(otherFollowers);
-			otherStreamService.SetupGet(j => j.Name).Returns("Other");
 
 			// act
-			var sut = new Fritz.StreamTools.Services.StreamService(new[] {
-				jeffStreams.Object, otherStreamService.Object });
-			var count = sut.FollowerCountByService;
+			var sut = new Fritz.StreamTools.Services.StreamService(new[] { jeffStreams, otherStreamService });
+			var count = sut.FollowerCountByService.ToList();
 
 			// assert
 			Assert.Equal(2, count.Count());
-			Assert.Contains(count, c => c.service == "Jeff");
-			Assert.Contains(count, c => c.service == "Other");
-			Assert.Equal(jeffsFollowers, count.First(c => c.service == "Jeff").count);
-			Assert.Equal(otherFollowers, count.First(c => c.service == "Other").count);
+			Assert.Contains(count, c => c.service == jeffStreams.Name);
+			Assert.Contains(count, c => c.service == otherStreamService.Name);
+			Assert.Equal(jeffStreams.CurrentFollowerCount, count.First(c => c.service == jeffStreams.Name).count);
+			Assert.Equal(otherStreamService.CurrentFollowerCount, count.First(c => c.service == otherStreamService.Name).count);
 
 
 		}

--- a/Test/Services/StreamService/Sum.cs
+++ b/Test/Services/StreamService/Sum.cs
@@ -1,55 +1,44 @@
 ﻿using Fritz.StreamTools.Services;
-using Moq;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace Test.Services.StreamService
 {
 
 
-	public class Sum : BaseFixture
+	public class Sum
 	{
 
-		[Fact]
-		public void CurrentFollowerCountHandlesOneService()
+		[Theory]
+		[AutoMoqStreamServiceWithNameAndCount]
+		public void CurrentFollowerCountHandlesOneService(IStreamService jeffStreams)
 		{
 
 
 			// arrange
-			var jeffStreams = Mockery.Create<IStreamService>();
-			var currentFollowers = new Random().Next(10, 100);
-			jeffStreams.SetupGet(j => j.CurrentFollowerCount).Returns(currentFollowers);
 
 			// act
-			var sut = new Fritz.StreamTools.Services.StreamService(new[] { jeffStreams.Object });
+			var sut = new Fritz.StreamTools.Services.StreamService(new[] { jeffStreams });
 			var sum = sut.CurrentFollowerCount;
 
 			// assert
-			Assert.Equal(currentFollowers, sum);
+			Assert.Equal(jeffStreams.CurrentFollowerCount, sum);
 
 		}
 
-		[Fact]
-		public void CurrentFollowerCountHandlesMultipleServices()
+		[Theory]
+		[AutoMoqStreamServiceWithNameAndCount]
+		public void CurrentFollowerCountHandlesMultipleServices(IStreamService jeffStreams, IStreamService otherStreamService)
 		{
 
 
 			// arrange
-			var jeffStreams = Mockery.Create<IStreamService>();
-			var otherStreamService = Mockery.Create<IStreamService>();
-			var jeffsFollowers = new Random().Next(10, 100);
-			jeffStreams.SetupGet(j => j.CurrentFollowerCount).Returns(jeffsFollowers);
-			var otherFollowers = new Random().Next(10, 100);
-			otherStreamService.SetupGet(j => j.CurrentFollowerCount).Returns(otherFollowers);
 
 			// act
-			var sut = new Fritz.StreamTools.Services.StreamService(new[] { jeffStreams.Object, otherStreamService.Object });
+			var sut = new Fritz.StreamTools.Services.StreamService(new[] { jeffStreams, otherStreamService });
 			var sum = sut.CurrentFollowerCount;
 
 			// assert
-			Assert.Equal((jeffsFollowers + otherFollowers), sum);
+			Assert.Equal(jeffStreams.CurrentFollowerCount + otherStreamService.CurrentFollowerCount, sum);
 
 		}
 

--- a/Test/Services/StreamService/ViewerCountByService.cs
+++ b/Test/Services/StreamService/ViewerCountByService.cs
@@ -1,39 +1,29 @@
 ﻿using Fritz.StreamTools.Services;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Linq;
 using Xunit;
 
 namespace Test.Services.StreamService
 {
 
-	public class ViewerCountByService : BaseFixture
+	public class ViewerCountByService
 	{
 
-		[Fact]
-		public void ShouldCountSeparately() {
+		[Theory]
+		[AutoMoqStreamServiceWithNameAndCount]
+
+		public void ShouldCountSeparately(IStreamService jeffStreams, IStreamService otherStreamService)
+		{
 
 			// arrange
-			var jeffStreams = Mockery.Create<IStreamService>();
-			var jeffsViewers = new Random().Next(10, 100);
-			jeffStreams.SetupGet(j => j.CurrentViewerCount).Returns(jeffsViewers);
-			jeffStreams.SetupGet(j => j.Name).Returns("Jeff");
-
-			var otherStreamService = Mockery.Create<IStreamService>();
-			var otherViewers = new Random().Next(10, 100);
-			otherStreamService.SetupGet(j => j.CurrentViewerCount).Returns(otherViewers);
-			otherStreamService.SetupGet(j => j.Name).Returns("Other");
 
 			// act
-			var sut = new Fritz.StreamTools.Services.StreamService(new[] {
-				jeffStreams.Object, otherStreamService.Object });
-			var count = sut.ViewerCountByService;
+			var sut = new Fritz.StreamTools.Services.StreamService(new[] { jeffStreams, otherStreamService });
+			var count = sut.ViewerCountByService.ToList();
 
 			// assert
 			Assert.Equal(2, count.Count());
-			Assert.Equal(jeffsViewers, count.First(c => c.service == "Jeff").count);
-			Assert.Equal(otherViewers, count.First(c => c.service == "Other").count);
+			Assert.Equal(jeffStreams.CurrentViewerCount, count.First(c => c.service == jeffStreams.Name).count);
+			Assert.Equal(otherStreamService.CurrentViewerCount, count.First(c => c.service == otherStreamService.Name).count);
 
 
 		}

--- a/Test/Services/TwitchService/OnNewFollowers.cs
+++ b/Test/Services/TwitchService/OnNewFollowers.cs
@@ -1,92 +1,65 @@
 ﻿using Fritz.StreamTools.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Moq;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using TwitchLib.Interfaces;
+using TwitchLib.Events.Services.FollowerService;
 using Xunit;
 using FRITZ = Fritz.StreamTools.Services;
 
 namespace Test.Services.TwitchService
 {
 
-	public class OnNewFollowers : BaseFixture
+	public class OnNewFollowers
 	{
-		private const int initialFollowers = 10;
 
-		public OnNewFollowers()
-		{
-			CreateLogger();
-			this.MockConfiguration = Mockery.Create<IConfiguration>();
+		[Theory]
+		[AutoMoqData]
 
-		}
-
-		private void CreateLogger()
-		{
-			MockLoggerFactory = Mockery.Create<ILoggerFactory>();
-			MockLogger = Mockery.Create<ILogger>();
-
-			MockLoggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(MockLogger.Object);
-
-		}
-
-		private Mock<ILoggerFactory> MockLoggerFactory { get; set; }
-		private Mock<ILogger> MockLogger { get; set; }
-		public Mock<IConfiguration> MockConfiguration { get; set; }
-
-		[Fact]
-		public void ShouldSetCurrentFollowerCount()
+		public void ShouldSetCurrentFollowerCount(
+			IConfiguration configuration,
+			ILoggerFactory loggerFactory,
+			int initialFollowers,
+			OnNewFollowersDetectedArgs args)
 		{
 
 			// arrange
-			var newFollowerCount = new Random().Next(400, 500);
-			var newFollowerList = new List<IFollow>(new IFollow[newFollowerCount]);
-			var args = new TwitchLib.Events.Services.FollowerService.OnNewFollowersDetectedArgs
-			{
-				NewFollowers = newFollowerList
-			};
-			//MockLogger.Setup(l => LoggerExtensions.LogInformation(l, It.IsAny<string>()))
-			//	.Callback<string>(msg => Console.Out.WriteLine(msg));
 
 			// act
-			var sut = new FRITZ.TwitchService(MockConfiguration.Object, MockLoggerFactory.Object)
+			var sut = new FRITZ.TwitchService(configuration, loggerFactory)
 			{
 				CurrentFollowerCount = initialFollowers
 			};
+
 			sut.Service_OnNewFollowersDetected(null, args);
 
 			// assert
-			Assert.Equal(newFollowerCount+initialFollowers, sut.CurrentFollowerCount);
+			Assert.Equal(args.NewFollowers.Count + initialFollowers, sut.CurrentFollowerCount);
 
 		}
 
-		[Fact]
-		public void ShouldRaiseEventProperly() {
+
+		[Theory]
+		[AutoMoqData]
+		public void ShouldRaiseEventProperly(
+			IConfiguration configuration,
+			ILoggerFactory loggerFactory,
+			int initialFollowers,
+			OnNewFollowersDetectedArgs args)
+		{
 
 			// arrange
-			var newFollowerCount = new Random().Next(400, 500);
-			var newFollowerList = new List<IFollow>(new IFollow[newFollowerCount]);
-			var myArgs = new TwitchLib.Events.Services.FollowerService.OnNewFollowersDetectedArgs
-			{
-				NewFollowers = newFollowerList
-			};
-
-			// act
-			var sut = new FRITZ.TwitchService(MockConfiguration.Object, MockLoggerFactory.Object)
+			var sut = new FRITZ.TwitchService(configuration, loggerFactory)
 			{
 				CurrentFollowerCount = initialFollowers
 			};
 
-			// arrange
+			// assert
 			var evt = Assert.Raises<ServiceUpdatedEventArgs>(
 				h => sut.Updated += h,
 				h => sut.Updated -= h,
-				() => sut.Service_OnNewFollowersDetected(null, myArgs)
+				() => sut.Service_OnNewFollowersDetected(null, args)
 			);
 
-			Assert.Equal(initialFollowers + newFollowerCount, evt.Arguments.NewFollowers);
+			Assert.Equal(initialFollowers + args.NewFollowers.Count, evt.Arguments.NewFollowers);
 			Assert.Null(evt.Arguments.NewViewers);
 
 		}

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.0.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.0.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
- Add AutoFixture necessary nuget packages to project for testing with XUnit2 and Moq.
- Create AutoDataAttributes to help generating fixtures.
- Replace current unit tests with AutoDataAttributes and remove the use of BaseFixture.

Fixes #18 