### PR TITLE
Adding MockService #20

### DIFF
--- a/Fritz.StreamTools/Pages/CurrentViewers.cshtml
+++ b/Fritz.StreamTools/Pages/CurrentViewers.cshtml
@@ -13,14 +13,14 @@
 </head>
 <body>
 
-	@foreach (var service in Model.StreamService.CountByService.OrderByDescending(s => s.service))
+	@foreach (var service in Model.StreamService.FollowerCountByService.OrderByDescending(s => s.service))
 	{
 
 		@service.service <text>:</text> <span class="serviceCount" id="@service.service.ToLowerInvariant()Count">@service.count</span>
 
 	}
 
-	Total: <span id="totalCount">@(Model.StreamService.CountByService.Sum(s => s.count))</span>
+	Total: <span id="totalCount">@(Model.StreamService.FollowerCountByService.Sum(s => s.count))</span>
 
 	<script src="~/js/signalr-client.min.js"></script>
 	<script type="text/javascript">

--- a/Fritz.StreamTools/Services/MixerService.cs
+++ b/Fritz.StreamTools/Services/MixerService.cs
@@ -204,7 +204,7 @@ namespace Fritz.StreamTools.Services
 
         Updated?.Invoke(this, new ServiceUpdatedEventArgs
         {
-          ServiceName = "Mixer",
+          ServiceName = Name,
           NewFollowers = data["numFollowers"].Value<int>()
         });
       }
@@ -216,7 +216,7 @@ namespace Fritz.StreamTools.Services
         {
           Updated?.Invoke(this, new ServiceUpdatedEventArgs
           {
-            ServiceName = "Mixer",
+            ServiceName = Name,
             NewViewers = data["viewersCurrent"].Value<int>()
         });
         }

--- a/Fritz.StreamTools/Services/MockService.cs
+++ b/Fritz.StreamTools/Services/MockService.cs
@@ -1,0 +1,142 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Fritz.StreamTools.Services
+{
+	public class MockService : IHostedService, IStreamService {
+
+		IConfiguration _config;
+
+		int _numberOfFollowers;
+		int _numberOfViewers;
+		int _updateViewersInterval;
+		int _updateFollowersInterval;
+		Timer _updateViewers;
+		Timer _updateFollowers;
+
+		public string Name => "Mock";
+
+		public ILogger Logger { get; }
+
+		public MockService (IConfiguration config, ILoggerFactory loggerFactory) {
+
+			this._config = config;
+			this.Logger = loggerFactory.CreateLogger("StreamServices");
+
+		}
+
+		public int CurrentFollowerCount => _numberOfFollowers;
+
+		public int CurrentViewerCount => _numberOfViewers;
+
+		public event EventHandler<ServiceUpdatedEventArgs> Updated;
+
+		public Task StartAsync(CancellationToken cancellationToken) {
+
+			_numberOfFollowers = int.Parse("0" + _config["StreamServices:Mock:CurrentFollowerCount"]);
+			_numberOfViewers = int.Parse("0" + _config["StreamServices:Mock:CurrentViewerCount"]);
+			_updateViewersInterval = int.Parse("0" + _config["StreamServices:Mock:UpdateViewersInterval"]);
+			_updateFollowersInterval = int.Parse("0" + _config["StreamServices:Mock:UpdateFollowersInterval"]);
+
+			Logger.LogInformation($"Now monitoring Mock with {CurrentFollowerCount} followers and {CurrentViewerCount} Viewers");
+
+			SetupViewerUpdateTimer();
+			SetupFollowerUpdateTimer();
+
+			return Task.CompletedTask;
+
+		}
+
+		private void SetupFollowerUpdateTimer()
+		{
+			if (_updateFollowersInterval == default(int))
+			{
+				return;
+			}
+
+			_updateFollowers = new Timer((o) =>
+			{
+
+				if (_numberOfFollowers >= 100)
+				{
+					_numberOfFollowers = 1;
+				}
+
+				_numberOfFollowers++;
+
+				Logger.LogInformation($"New Followers on Mock, new total: {_numberOfFollowers}");
+
+				Updated?.Invoke(
+					null,
+					new ServiceUpdatedEventArgs()
+					{
+						NewFollowers = _numberOfFollowers,
+						ServiceName = Name
+					});
+
+			},
+			null,
+			4000,
+			_updateFollowersInterval);
+
+		}
+
+		private void SetupViewerUpdateTimer()
+		{
+			if (_updateViewersInterval == default(int))
+			{
+				return;
+			}
+
+			_updateViewers = new Timer((o) =>
+			{
+
+				if (_numberOfViewers >= 100)
+				{
+					_numberOfViewers = 1;
+				}
+
+				_numberOfViewers++;
+
+				Logger.LogInformation($"New Followers on Mock, new total: {_numberOfViewers}");
+
+				Updated?.Invoke(
+					null,
+					new ServiceUpdatedEventArgs()
+					{
+						NewViewers = _numberOfViewers,
+						ServiceName = Name
+					});
+
+			},
+			null,
+			5000,
+			_updateViewersInterval);
+
+		}
+
+		public Task StopAsync(CancellationToken cancellationToken) {
+
+			Logger.LogInformation($"Stopping monitoring Mock with {CurrentFollowerCount} followers and {CurrentViewerCount} Viewers");
+
+			if (_updateViewers != null)
+			{
+				_updateViewers.Dispose();
+			}
+
+			if (_updateFollowers != null)
+			{
+				_updateFollowers.Dispose();
+			}
+
+			return Task.CompletedTask;
+
+		}
+	}
+}

--- a/Fritz.StreamTools/Services/TwitchService.cs
+++ b/Fritz.StreamTools/Services/TwitchService.cs
@@ -107,7 +107,7 @@ namespace Fritz.StreamTools.Services
         _CurrentViewerCount = (myStream.Stream?.Viewers ?? 0);
         Updated?.Invoke(null, new ServiceUpdatedEventArgs
         {
-          ServiceName = "Twitch",
+          ServiceName = Name,
           NewViewers = _CurrentViewerCount
         });
       }
@@ -122,7 +122,7 @@ namespace Fritz.StreamTools.Services
 
       Updated?.Invoke(this, new ServiceUpdatedEventArgs
       {
-        ServiceName = "Twitch",
+        ServiceName = Name,
         NewFollowers = _CurrentFollowerCount
       });
     }

--- a/Fritz.StreamTools/StartupServices/ConfigureServices.cs
+++ b/Fritz.StreamTools/StartupServices/ConfigureServices.cs
@@ -45,6 +45,8 @@ namespace Fritz.StreamTools.StartupServices
 
 			ConfigureMixer(services, Configuration, sp);
 
+			ConfigureMock(services, Configuration, sp);
+
 			services.AddSingleton<StreamService>();
 
 		}
@@ -68,6 +70,15 @@ namespace Fritz.StreamTools.StartupServices
 				var mxr = new MixerService(Configuration, sp.GetService<ILoggerFactory>());
 				services.AddSingleton<IHostedService>(mxr);
 				services.AddSingleton<IStreamService>(mxr);
+			}
+		}
+
+		private static void ConfigureMock(IServiceCollection services, IConfiguration Configuration, ServiceProvider sp)
+		{
+			if (Configuration["StreamServices:Mock:Switch"] == "on") {
+				var mck = new MockService(Configuration, sp.GetService<ILoggerFactory>());
+				services.AddSingleton<IHostedService>(mck);
+				services.AddSingleton<IStreamService>(mck);
 			}
 		}
 


### PR DESCRIPTION
Added a configurable MockService. I called this way but feel free to rename it. I created it based on issue #20, where was suggested the creation of a "DummyService", to help people without Twitch or Mixer keys.

This new service uses values from the configuration. Although, as it doesn't require a ClientID, I introduced a config called "switch". This service will only be injected and configured if "switch" == "on".