### PR TITLE
Refactor SignalrTagHelper to inject the client library source to its constructor

### DIFF
--- a/Fritz.StreamTools/StartupServices/ConfigureServices.cs
+++ b/Fritz.StreamTools/StartupServices/ConfigureServices.cs
@@ -1,14 +1,16 @@
-﻿using Fritz.StreamTools.Hubs;
+﻿using System;
+using System.IO;
+using System.Linq;
+using Fritz.StreamTools.Hubs;
 using Fritz.StreamTools.Models;
 using Fritz.StreamTools.Services;
+using Fritz.StreamTools.TagHelpers;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace Fritz.StreamTools.StartupServices
 {
@@ -31,6 +33,8 @@ namespace Fritz.StreamTools.StartupServices
 
 			ConfigureAspNetFeatures(services);
 
+			services.AddSingleton<IConfigureOptions<SignalrTagHelperOptions>, ConfigureSignalrTagHelperOptions>();
+			services.AddSingleton<SignalrTagHelperOptions>(cfg => cfg.GetService<IOptions<SignalrTagHelperOptions>>().Value);
 		}
 
 		private static void ConfigureStreamingServices(

--- a/Fritz.StreamTools/StartupServices/ConfigureSignalrTagHelperOptions.cs
+++ b/Fritz.StreamTools/StartupServices/ConfigureSignalrTagHelperOptions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using Fritz.StreamTools.TagHelpers;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Fritz.StreamTools.StartupServices
+{
+
+	public class ConfigureSignalrTagHelperOptions : IConfigureOptions<SignalrTagHelperOptions>
+	{
+
+		private readonly IHostingEnvironment Env;
+		private readonly ILogger Logger;
+
+		public ConfigureSignalrTagHelperOptions(IHostingEnvironment env, ILogger<ConfigureSignalrTagHelperOptions> logger)
+		{
+
+			Env = env;
+			Logger = logger;
+
+		}
+
+		public void Configure(SignalrTagHelperOptions options)
+		{
+
+			var folder = new DirectoryInfo(Path.Combine(Env.WebRootPath, "lib", "signalr"));
+
+			var fileInfo = folder.Exists
+				? folder.GetFiles("signalr-client-*.min.js").OrderByDescending(f => f.Name).FirstOrDefault()
+				: null;
+
+			if (fileInfo == null)
+			{
+				var error = "Required signalr-client library not found.";
+				Logger.LogCritical(error);
+				throw new InvalidOperationException(error);
+			}
+
+			options.ClientLibarySource = $"/lib/signalr/{fileInfo.Name}";
+
+		}
+
+	}
+
+}

--- a/Fritz.StreamTools/TagHelpers/SignalrTagHelper.cs
+++ b/Fritz.StreamTools/TagHelpers/SignalrTagHelper.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Abstractions;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
+﻿using Fritz.StreamTools.StartupServices;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace Fritz.StreamTools.TagHelpers
@@ -15,38 +8,22 @@ namespace Fritz.StreamTools.TagHelpers
 	public class SignalrTagHelper : TagHelper
 	{
 
-		public SignalrTagHelper(IHostingEnvironment env) {
+		private readonly SignalrTagHelperOptions Options;
 
-			this.HostingEnvironment = env;
-
+		public SignalrTagHelper(SignalrTagHelperOptions options)
+		{
+			Options = options;
 		}
-
-		private readonly IHostingEnvironment HostingEnvironment;
 
 		public override void Process(TagHelperContext context, TagHelperOutput output)
 		{
 
 			output.TagName = "script";
 			output.TagMode = TagMode.StartTagAndEndTag;
-
-			var filename = IdentifyClientLibrary(new FileSystem(), HostingEnvironment.WebRootPath);
-
-			output.Attributes.Add("src", filename);
+			output.Attributes.Add("src", Options.ClientLibarySource);
 
 		}
 
-		internal string IdentifyClientLibrary(IFileSystem fileSystem, string webRootPath)
-		{
-
-			var folderName = fileSystem.Path.Combine(webRootPath, "lib/signalr");
-			var folder = fileSystem.DirectoryInfo.FromDirectoryName(folderName);
-
-			var fileInfo = folder.GetFiles("signalr-client-*.min.js")
-				.OrderByDescending(f => f.Name).First();
-
-			return $"~/lib/signalr/{fileInfo.Name}";
-
-
-		}
 	}
+
 }

--- a/Fritz.StreamTools/TagHelpers/SignalrTagHelperOptions.cs
+++ b/Fritz.StreamTools/TagHelpers/SignalrTagHelperOptions.cs
@@ -1,0 +1,11 @@
+﻿namespace Fritz.StreamTools.TagHelpers
+{
+
+    public class SignalrTagHelperOptions
+    {
+
+	    public string ClientLibarySource { get; set; }
+
+    }
+
+}

--- a/Test/TagHelpers/SignalrTagHelper/IdentifyClientLibrary.cs
+++ b/Test/TagHelpers/SignalrTagHelper/IdentifyClientLibrary.cs
@@ -20,7 +20,7 @@ namespace Test.TagHelpers.SignalrTagHelper
 			var fileSystem = Mockery.Create<IFileSystem>();
 
 			// act
-			var sut = new WEB.TagHelpers.SignalrTagHelper(hostingEnvironment.Object);
+			//var sut = new WEB.TagHelpers.SignalrTagHelper(hostingEnvironment.Object);
 			// var result = sut.IdentifyClientLibrary(fileSystem.Object, "TESTPATH");
 
 			// assert

--- a/Test/TagHelpers/SignalrTagHelper/Process.cs
+++ b/Test/TagHelpers/SignalrTagHelper/Process.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using Fritz.StreamTools.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace Test.TagHelpers.SignalrTagHelper
+{
+
+	public class Process
+	{
+
+		[Theory]
+		[AutoMoqData]
+		public void ReturnsScriptTag(SignalrTagHelperOptions options, TagHelperContext context, TagHelperOutput output)
+		{
+
+			// arrange
+			var sut = new Fritz.StreamTools.TagHelpers.SignalrTagHelper(options);
+
+			// act
+			sut.Process(context, output);
+
+			// assert
+			Assert.Equal("script", output.TagName);
+			Assert.Equal(TagMode.StartTagAndEndTag, output.TagMode);
+			Assert.Single(output.Attributes);
+			Assert.Equal("src", output.Attributes.First().Name);
+			Assert.Equal(options.ClientLibarySource, output.Attributes.First().Value);
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
Injecting the client library source to the **SignalrTagHelper** keeps it's responsibility to only generate a script tag. Finding the client library source is delegated to the DI services configuration.

In order to inject this client library source, I created a **SignalrTagHelperOptions** class. This class can be configured within the DI system and is used as a parameter to the **SignalrTagHelper** constructor. 

To facilitate DI configuration, I created the **ConfigureSignalrTagHelperOptions** class which inherits from **IConfigureOptions<SignalrTagHelperOptions>**.  I then configure DI to make use of it.

_ConfigureServices.cs_
```csharp
services.AddSingleton<IConfigureOptions<SignalrTagHelperOptions>, ConfigureSignalrTagHelperOptions>();
```

In order to hook the **IConfigureOptions<SignalrTagHelperOptions>**, we should normally use **IOptions<SignalrTagHelperOptions>** as a parameter of the **SignalrTagHelper** constructor. I don't really like using the **IOptions<>** interface in my constructors because its adds complexity in my unit tests. Therefore, I used a little trick in DI configuration :

_ConfigureServices.cs_
```csharp
services.AddSingleton<SignalrTagHelperOptions>(cfg => cfg.GetService<IOptions<SignalrTagHelperOptions>>().Value);
```

Finally I added a simple unit test which validates the output of the process function using AutoFixture.

BTW, the attribute **AutoData** is part of **AutoFixture** and allows us to generate fixtures for simples types as **string**. For **interfaces**, we need **Moq** and therefore the **AutoMoqData**. By default, Moq doesn't populate properties. So for generating fixtures of **IStreamService** with **Name**, **CurrentFollowerCount** and **CurrentViewerCount** properties, I had to create the **AutoMoqStreamServiceWithNameAndCountAttribute**.


fixes #24 