### PR TITLE
Adding Google Fonts API query support

### DIFF
--- a/Fritz.StreamTools/Controllers/FollowersController.cs
+++ b/Fritz.StreamTools/Controllers/FollowersController.cs
@@ -23,7 +23,8 @@ namespace Fritz.StreamTools.Controllers
 			StreamService streamService,
 			IOptions<FollowerGoalConfiguration> config,
 			IHostingEnvironment env,
-			FollowerClient followerClient)
+			FollowerClient followerClient,
+			IConfiguration appConfig)
 		{
 			this.StreamService = streamService;
 			this.Configuration = config.Value;
@@ -31,12 +32,15 @@ namespace Fritz.StreamTools.Controllers
 
 			this.HostingEnvironment = env;
 			this.FollowerClient = followerClient;
+
+			this.AppConfig = appConfig;
 		}
 
 		public StreamService StreamService { get; }
 		public FollowerGoalConfiguration Configuration { get; }
 		public IHostingEnvironment HostingEnvironment { get; }
 		public FollowerClient FollowerClient { get; }
+		public IConfiguration AppConfig { get; }
 
 
 		[HttpGet("api/Followers")]
@@ -120,6 +124,7 @@ namespace Fritz.StreamTools.Controllers
 		[Route("followers/goal/preview")]
 		public IActionResult PreviewGoal() {
 
+			ViewBag.GoogleFontsApiKey = AppConfig["GoogleFontsApi:Key"];
 			return View();
 
 		}

--- a/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
+++ b/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
@@ -67,17 +67,21 @@
 
 		<fieldset>
 
-			<label>Caption:</label> <input type="text" id="caption" value="Configure Me" />
+			<label for="caption">Caption:</label> <input type="text" id="caption" value="Configure Me" />
 			<br />
-			<label>Goal:</label> <input type="text" id="goal" value="100" />
+			<label for="goal">Goal:</label> <input type="text" id="goal" value="100" />
 			<br />
-			<label>Test Count:</label> <input type="text" id="current" value="90" />
+			<label for="current">Test Count:</label> <input type="text" id="current" value="90" />
 			<br />
-			<label>Google Font:</label> <input type="text" id="fontname" value="" />
+			<label for="fontname">Google Font:</label> <input type="text" id="fontname" value="" />
 			<br />
-			<label>Empty Bg Color:</label> <input type="color" id="emptyBgColor" />
+			<div id="fontsPanel">
+				<label for="fontname"></label> <select id="fontNames" size="5"></select>
+				<br />
+			</div>
+			<label for="emptyBgColor">Empty Bg Color:</label> <input type="color" id="emptyBgColor" />
 			<br />
-			<label>Empty Font Color:</label> <input type="color" id="emptyFontColor" />
+			<label for="emptyFontColor">Empty Font Color:</label> <input type="color" id="emptyFontColor" />
 			<br />
 			<label>Fill Bar Colors:</label>
 			<div id="bgcolors">
@@ -102,6 +106,10 @@
 	<script type="text/javascript">
 <!--
 		(function () {
+
+			document.getElementById('fontsPanel').style.display = 'none';
+
+			var supportedFonts = [];
 
 			onload();
 
@@ -139,6 +147,15 @@
 				for (var i = 0; i < localStorage.length; i++) {
 					var key = localStorage.key(i);
 					var item = localStorage.getItem(key);
+
+					if (key === 'supportedFonts') {
+
+						var fonts = JSON.parse(item);
+						setSupportedFonts(fonts);
+						continue;
+
+					}
+
 					console.log(key, item);
 
 					// store an array of all the required color pickers
@@ -178,6 +195,8 @@
 
 				}
 
+				if (supportedFonts.length == 0)
+					googleFontsAdapter(setSupportedFontsFromApi);
 
 			}
 
@@ -194,6 +213,7 @@
 
 				}
 
+				localStorage.setItem('supportedFonts', JSON.stringify(supportedFonts));
 
 			}
 
@@ -222,6 +242,75 @@
 				}
 				return result;
 			}
+
+			// retrieve the supported font names from google api
+			function googleFontsAdapter(setter) {
+				@*Reference for the HTTP in vanilla JS https://www.sitepoint.com/guide-vanilla-ajax-without-jquery/*@
+				let api = 'https://www.googleapis.com/webfonts/v1/webfonts?key=@ViewBag.GoogleFontsApiKey';
+
+				@if (string.IsNullOrEmpty(ViewBag.GoogleFontsApiKey))
+				{
+					@:setter([{ 'family': 'Aclonica' }, { 'family': 'Mallanna' }]);
+					@:return;
+				}
+
+				let xhr = new XMLHttpRequest();
+				xhr.open('GET', api);
+				xhr.send(null);
+
+				console.log('Calling google fonts api');
+
+				xhr.onreadystatechange = function() {
+					let DONE = 4; // readyState 4 means the request is done.
+					let OK = 200; // status 200 is a successful return.
+					if (xhr.readyState === DONE) {
+						if (xhr.status === OK)
+							setter(JSON.parse(xhr.responseText).items); // 'This is the returned text.'
+						else
+							console.log('Error: ' + xhr.status); // An error occurred during the request.
+					}
+				}
+			}
+
+			function setSupportedFonts(fonts) {
+				localStorage.setItem('supportedFonts', JSON.stringify(supportedFonts));
+				updateFontList(filterFontList(supportedFonts));
+			}
+
+			function setSupportedFontsFromApi(value) {
+				supportedFonts = value.map((v) => v.family);
+				setSupportedFonts(supportedFonts);
+			}
+
+			function filterFontList(fonts, search) {
+				return fonts.filter(function (item) { return !search || item.indexOf(search) > -1; })
+			}
+
+			function updateFontList(fonts) {
+				let control = document.getElementById('fontNames');
+				control.innerHTML = '';
+				for (var current of fonts) {
+					let option = document.createElement("option");
+					option.text = current;
+					control.add(option);
+				}
+			}
+
+			document.getElementById('fontname').onkeyup = function (d) {
+
+				if (d.keyCode < 65 || d.keyCode > 90)
+					return;
+				document.getElementById('fontsPanel').style.display = '';
+				updateFontList(filterFontList(supportedFonts, this.value));
+
+			};
+
+			document.getElementById('fontNames').onchange = function () {
+
+				document.getElementById('fontsPanel').style.display = 'none';
+				document.getElementById('fontname').value = this.value;
+
+			};
 
 		})();
 

--- a/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
+++ b/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
@@ -122,7 +122,7 @@
 				var iframeWidth = document.getElementById("widgetPreview").clientWidth - 40;
 				let fontName = document.getElementById("fontname").value;
 
-				if (supportedFonts.length > 0 && filterFontList(supportedFonts, fontName).length === 0) {
+				if (supportedFonts.length > 0 && filterFontList(supportedFonts, fontName, filterExactMatchOperation).length !== 1) {
 					alert('Font not supported by Google Fonts');
 					return;
 				}
@@ -288,8 +288,16 @@
 				setSupportedFonts(supportedFonts);
 			}
 
-			function filterFontList(fonts, search) {
-				return fonts.filter(function (item) { return !search || item.indexOf(search) > -1; })
+			function filterExactMatchOperation(currentItem, searchValue) {
+				return !searchValue || currentItem === searchValue;
+			}
+
+			function filterPartialMatchOperation(currentItem, searchValue) {
+				return !searchValue || currentItem.indexOf(searchValue) > -1;
+			}
+
+			function filterFontList(fonts, searchValue, searchOperation = filterPartialMatchOperation) {
+				return fonts.filter(function (currentItem) { return searchOperation(currentItem, searchValue); });
 			}
 
 			function updateFontList(fonts) {

--- a/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
+++ b/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
@@ -22,7 +22,7 @@
 			overflow-x: hidden;
 		}
 
-		input, label {
+		input, label, #fontNames {
 			width: 10em;
 			display: inline-block;
 		}
@@ -120,6 +120,12 @@
 			function LoadPreview() {
 
 				var iframeWidth = document.getElementById("widgetPreview").clientWidth - 40;
+				let fontName = document.getElementById("fontname").value;
+
+				if (supportedFonts.length > 0 && filterFontList(supportedFonts, fontName).length === 0) {
+					alert('Font not supported by Google Fonts');
+					return;
+				}
 
 				var urlTemplate = "/followers/goal/";
 				urlTemplate += `${document.getElementById("goal").value}/`;
@@ -129,7 +135,7 @@
 				urlTemplate += getBGBlend();
 				urlTemplate += `&emptyBgColor=${escape(document.getElementById("emptyBgColor").value)}`;
 				urlTemplate += `&emptyFontColor=${escape(document.getElementById('emptyFontColor').value)}`;
-				urlTemplate += getFontName();
+				urlTemplate += `&fontName=${escape(fontName)}`;
 
 				document.getElementById("widgetPreview").src = urlTemplate + `&current=${document.getElementById("current").value}`
 				console.log(urlTemplate);
@@ -298,7 +304,7 @@
 
 			document.getElementById('fontname').onkeyup = function (d) {
 
-				if (d.keyCode < 65 || d.keyCode > 90)
+				if (d.keyCode != 8 && (d.keyCode < 65 || d.keyCode > 90))
 					return;
 				document.getElementById('fontsPanel').style.display = '';
 				updateFontList(filterFontList(supportedFonts, this.value));
@@ -347,11 +353,7 @@
 				spans[i].children[1].id = `bgblend${i + 1}`;
 			}
 		}
-
-		function getFontName() {
-			var fontName = document.getElementById("fontname").value;
-			return `&fontName=${escape(fontName)}`;
-		}
+		
 //-->
 	</script>
 

--- a/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
+++ b/Fritz.StreamTools/Views/Followers/PreviewGoal.cshtml
@@ -52,6 +52,10 @@
 			display: inline-flex;
 		}
 
+		#fontNames {
+			font-size: 2em;
+		}
+
 	</style>
 
 </head>
@@ -283,8 +287,8 @@
 				updateFontList(filterFontList(supportedFonts));
 			}
 
-			function setSupportedFontsFromApi(value) {
-				supportedFonts = value.map((v) => v.family);
+			function setSupportedFontsFromApi(fonts) {
+				supportedFonts = fonts.map((v) => v.family);
 				setSupportedFonts(supportedFonts);
 			}
 
@@ -300,19 +304,56 @@
 				return fonts.filter(function (currentItem) { return searchOperation(currentItem, searchValue); });
 			}
 
+			function createCssLinkTag(encoded) {
+
+				if (document.getElementById(`font-${encoded}`))
+					return;
+
+				let l = document.createElement('link');
+				l.type = 'text/css';
+				l.rel = 'stylesheet';
+				l.id = `font-${encoded}`;
+				l.href = `https://fonts.googleapis.com/css?family=${encoded}`;
+
+				document.getElementsByTagName('head')[0].appendChild(l);
+
+			}
+
+			function createFontOption(fontFamily) {
+
+				let option = document.createElement("option");
+				option.style.fontFamily = fontFamily;
+				option.text = fontFamily;
+				return option;
+
+			}
+
 			function updateFontList(fonts) {
+
 				let control = document.getElementById('fontNames');
 				control.innerHTML = '';
+
 				for (var current of fonts) {
-					let option = document.createElement("option");
-					option.text = current;
-					control.add(option);
+					let encoded = encodeURI(current);
+
+					createCssLinkTag(encoded);
+					
+					control.add(createFontOption(current));
 				}
+
 			}
 
 			document.getElementById('fontname').onkeyup = function (d) {
 
-				if (d.keyCode != 8 && (d.keyCode < 65 || d.keyCode > 90))
+				//console.log(d.keyCode);
+				if (
+					d.keyCode != 8
+					&& d.keyCode != 32
+					&& d.keyCode != 46
+					&& (
+						d.keyCode < 65
+						|| d.keyCode > 90)
+				)
 					return;
 				document.getElementById('fontsPanel').style.display = '';
 				updateFontList(filterFontList(supportedFonts, this.value));

--- a/Fritz.StreamTools/appsettings.json
+++ b/Fritz.StreamTools/appsettings.json
@@ -34,5 +34,8 @@
 		"FillFontColor": "#FFF",
 		"FillBackgroundColorBlend": "1, 0, 1",
 		"FontName": ""
+	},
+	"GoogleFontsApi": {
+		"Key": ""
 	}
 }


### PR DESCRIPTION
The user will be required to get an API Key in order to use it https://developers.google.com/fonts/docs/developer_api (avoid doing this on camera because the value will be displayed. You can constraint the calls from a given domain name. I used localhost and worked fine).

The key will be read from secrets.json or appsetting.json.

Also added a check to alert the user when clicking on preview in case the font name is not in the supported list.

No jQuery. All vanilla JS 😎 

PS.: Also added "for" on the label elements so when you click on a label, its control gets focus.