### PR TITLE
Fix Local Storage Issues

### DIFF
--- a/Fritz.StreamTools/Views/Followers/GoalConfiguration.cshtml
+++ b/Fritz.StreamTools/Views/Followers/GoalConfiguration.cshtml
@@ -94,6 +94,8 @@
 	// "fontname",
 	const quickPreviewTextBoxes = ["preview", "caption", "goal", "currentValue", "emptyBackgroundColor", "emptyFontColor", "bgcolor1", "bgblend1"];
 
+		var isLoadingFromStorage = false;
+
 		(function () {
 
 			document.getElementById('fontsPanel').style.display = 'none';
@@ -107,6 +109,8 @@
 			}
 
 			function onload() {
+
+				isLoadingFromStorage = true;
 
 				const bgArray = new Array();
 
@@ -165,10 +169,14 @@
 				if (supportedFonts.length == 0)
 					googleFontsAdapter(setSupportedFontsFromApi);
 
-				}
+				isLoadingFromStorage = false;
+			}
+
 		})();
 
 			function loadPreview() {
+
+				if (isLoadingFromStorage) return;
 
 				const iframeWidth = document.getElementById("widgetPreview").clientWidth - 40;
 				const fontName = document.getElementById("fontname").value;
@@ -376,7 +384,7 @@
 				const addButton = spans[spans.length - 1].nextSibling,
 					newNode = spans[spans.length - 1].cloneNode(true),
 					bgColorField = newNode.getElementsByTagName('input')[0],
-					bgBlendField = newNode.getElementsByTagName('input')[0];
+					bgBlendField = newNode.getElementsByTagName('input')[1];
 
 				bgColorField.id = key ? `bgcolor${key}` : `bgcolor${spans.length + 1}`;
 				bgColorField.onchange = loadPreview;


### PR DESCRIPTION
The use of onchange events was causing local storage to be overwritten with default values.

I added a flag to indicate that we are loading values from storage which is used to short-circuit the preview method and prevent this problem.

There was also a small problem with loading of saved background colors which I fixed on line 387.