### PR TITLE
Added npmrc file for aspnet/signalr

### DIFF
--- a/Fritz.StreamTools/.npmrc
+++ b/Fritz.StreamTools/.npmrc
@@ -1,0 +1,1 @@
+﻿@aspnet:registry=https://dotnet.myget.org/f/aspnetcore-dev/npm/


### PR DESCRIPTION
I added a .npmrc file to point to the correct registry for SignalR.

See https://github.com/aspnet/SignalR#readme under installation.

