### PR TITLE
Removed first width option from Goal widget preview

### DIFF
--- a/Fritz.StreamTools/Views/Home/Index.cshtml
+++ b/Fritz.StreamTools/Views/Home/Index.cshtml
@@ -24,7 +24,7 @@
 	
 	<div class="col-md-4">
 		<h4>Follower Goal</h4>
-		<iframe src="/followers/goal/100/Goal?width=890&FillBackgroundColor=%23800080,%2300ff00,%23ff8000&FillBackgroundColorBlend=1,1,1&EmptyBackgroundColor=%23cccccc&EmptyFontColor=%23000000&FillFontColor=%23ffffff&fontName=Carter%20One&width=280&CurrentValue=95" scrolling="no"></iframe>
+		<iframe src="/followers/goal/100/Goal?FillBackgroundColor=%23800080,%2300ff00,%23ff8000&FillBackgroundColorBlend=1,1,1&EmptyBackgroundColor=%23cccccc&EmptyFontColor=%23000000&FillFontColor=%23ffffff&fontName=Carter%20One&width=280&CurrentValue=95" scrolling="no"></iframe>
 		<br/>
 		<a asp-controller="Followers" asp-action="Goal">/Followers/Goal</a>
 	</div>


### PR DESCRIPTION
The widget preview had two "width" parameters which was causing it to display incorrectly.