### PR TITLE
SignalR viewers & followers groups

### DIFF
--- a/Fritz.StreamTools/Hubs/FollowerHub.cs
+++ b/Fritz.StreamTools/Hubs/FollowerHub.cs
@@ -1,4 +1,5 @@
-﻿using Fritz.StreamTools.Services;
+﻿using System.Net.Mime;
+using Fritz.StreamTools.Services;
 using Microsoft.AspNetCore.SignalR;
 using System;
 using System.Collections.Generic;
@@ -23,6 +24,20 @@ namespace Fritz.StreamTools.Hubs
 			this.FollowerClient = client;
 
 			StreamService.Updated += StreamService_Updated;
+		}
+
+		public override async Task OnConnectedAsync()
+		{
+			var groupNames = Context.Connection.GetHttpContext().Request.Query["groups"].SingleOrDefault();
+			if (groupNames != null)
+			{
+				// Join the group(s) the user has specified in the 'groups' query-string
+				// NOTE: SignalR will automatically take care of removing the client from the group(s) when they disconnect
+				foreach (var groupName in groupNames.Split(','))
+					await Groups.AddAsync(Context.ConnectionId, groupName.ToLowerInvariant());
+			}
+
+			await base.OnConnectedAsync();
 		}
 
 		private void StreamService_Updated(object sender, ServiceUpdatedEventArgs e)

--- a/Fritz.StreamTools/Pages/CurrentViewers.cshtml
+++ b/Fritz.StreamTools/Pages/CurrentViewers.cshtml
@@ -50,7 +50,7 @@
 
 			}
 
-			hub.start();
+			hub.start("viewers");
 
 		})();
 	</script>

--- a/Fritz.StreamTools/Services/FollowerClient.cs
+++ b/Fritz.StreamTools/Services/FollowerClient.cs
@@ -21,13 +21,13 @@ namespace Fritz.StreamTools.Services
 		public void UpdateFollowers(int newFollowers)
 		{
 
-			FollowerContext.Clients.All.SendAsync("OnFollowersCountUpdated", newFollowers);
+			FollowerContext.Clients.Group("followers").SendAsync("OnFollowersCountUpdated", newFollowers);
 
 		}
 
 		public void UpdateViewers(string serviceName, int viewerCount)
 		{
-			FollowerContext.Clients.All.SendAsync("OnViewersCountUpdated", serviceName.ToLowerInvariant(), viewerCount);
+			FollowerContext.Clients.Group("viewers").SendAsync("OnViewersCountUpdated", serviceName.ToLowerInvariant(), viewerCount);
 		}
 	}
 

--- a/Fritz.StreamTools/Views/Followers/Count.cshtml
+++ b/Fritz.StreamTools/Views/Followers/Count.cshtml
@@ -45,7 +45,7 @@
 								document.getElementById("count").textContent = count;
 						}
 
-						hub.start();
+						hub.start("followers");
 
 				})();
 		</script>

--- a/Fritz.StreamTools/Views/Followers/Goal.cshtml
+++ b/Fritz.StreamTools/Views/Followers/Goal.cshtml
@@ -95,7 +95,7 @@
 
 						if (window.self == window.top) {
 								console.log("Topmost window - enabling SignalR");
-								hub.start();
+								hub.start("followers");
 						} else {
 								console.log("hosted in a frame - disabling SignalR");
 						}

--- a/Fritz.StreamTools/wwwroot/js/streamhub.js
+++ b/Fritz.StreamTools/wwwroot/js/streamhub.js
@@ -7,8 +7,9 @@ class StreamHub {
 				this._hub = null;
 		}
 
-		start() {
-				this._hub = new signalR.HubConnection("/followerstream");
+		start(groups) {
+				let url = (groups) ? "/followerstream?groups=" + groups : "/followerstream";
+				this._hub = new signalR.HubConnection(url);
 
 				this._hub.onclose(() => {
 						if (this.debug) console.debug("hub connection closed");


### PR DESCRIPTION
This is a small change to demonstrate using groups in SignalR, as I saw somebody ask about it on stream.
The server now has two groups, 'viewers' and 'followers', and the client can join one or more of these by passing the wanted group as a querystring parameter.
I have changed the js streamhub.start() method to now accept a comma separated list of groups they want to join.

Another way of doing this would be to add a server hub functions like JoinGroup(...)  and LeaveGroup(...) that the client could call to join groups whenever they wanted. 
