### PR TITLE
Updated VersonTagHelper

### DIFF
--- a/Fritz.StreamTools/TagHelpers/VersionTagHelper.cs
+++ b/Fritz.StreamTools/TagHelpers/VersionTagHelper.cs
@@ -6,21 +6,67 @@ using System.Threading.Tasks;
 
 namespace Fritz.StreamTools.TagHelpers
 {
+	[HtmlTargetElement("version")]
 	public class VersionTagHelper : TagHelper
 	{
-
-		public override void Process(TagHelperContext context, TagHelperOutput output)
+		public enum VersionType
 		{
-
-			output.TagName = "span";
-			output.Attributes.Add("class", "text-muted");
-
-			var versionInfo = GetType().Assembly.GetName().Version;
-
-			output.Content.Append(versionInfo.ToString());
-
+			FileVersion = 1,
+			ProductVersion = 2,
+			InformationalVersion = 2,
+			AssemblyVersion = 3
 		}
 
+		/// <summary>
+		/// Assembly represents the type of the assembly to be versioned.
+		/// </summary>
+		[HtmlAttributeName("assembly")]
+		public System.Type AssemblyType { get; set; }
 
-	}
+		/// <summary>
+		/// Type represents the type of version to be returned
+		/// One of FileVersion, ProductVersion or AssemblyVersion
+		/// Defaults to ProductVersion (InformationalVersion)
+		/// </summary>
+		[HtmlAttributeName("type")]
+		public VersionType Type { get; set; } = VersionType.ProductVersion;
+
+		public async override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		{
+			var versionString = "";
+			output.TagName = "span";
+			output.TagMode = TagMode.StartTagAndEndTag;
+			var childContent = await output.GetChildContentAsync();
+			output.Content.AppendHtml(childContent);
+			if (AssemblyType == null)
+			{
+			AssemblyType = GetType();
+			}
+			switch (Type)
+			{
+			case VersionType.FileVersion:
+				versionString = AssemblyType
+					.GetTypeInfo().Assembly
+					.GetCustomAttribute<AssemblyFileVersionAttribute>()?
+					.Version ?? "";
+				break;
+			case VersionType.ProductVersion:    // also covers VersionType.InformationalVersion
+				versionString = AssemblyType
+					.GetTypeInfo().Assembly
+					.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+					.InformationalVersion ?? "";
+				break;
+			case VersionType.AssemblyVersion:
+				versionString = AssemblyType
+					.Assembly.GetName().Version.ToString();
+				break;
+			default:
+				break;
+			}
+			output.Content.Append(versionString);
+
+			await base.ProcessAsync(context, output);
+			return;
+		}
+  }
 }

--- a/Fritz.StreamTools/Views/Shared/_Footer.cshtml
+++ b/Fritz.StreamTools/Views/Shared/_Footer.cshtml
@@ -2,6 +2,6 @@
 <footer class="footer">
 		<div class="container">
 				<span class="text-muted">&copy; @DateTime.Now.Year - Jeff Fritz and Friends</span>
-				- <version></version>
+				- <version assembly="typeof(Program)" typeof="ProductVersion"/>
 		</div>
 </footer>


### PR DESCRIPTION
Pull Request to consistently return better version information with an updated VersionTagHelper

See the issue: **What is the best way to display version numbers in a web site with CI/CD?** #45

I do have a version that returns other Assembly metadata (copyright etc.), but this is the simplified one.