### PR TITLE
Pass groups on signalr reconnect

### DIFF
--- a/Fritz.StreamTools/wwwroot/js/streamhub.js
+++ b/Fritz.StreamTools/wwwroot/js/streamhub.js
@@ -17,7 +17,7 @@ class StreamHub {
 						// Hub connection was closed for some reason
 						let interval = setInterval(() => {
 								// Try to reconnect hub every 5 secs
-								this.start().then(() => {
+								this.start(groups).then(() => {
 										// Reconnect succeeded
 										clearInterval(interval);
 										if (this.debug) console.debug("hub reconnected");
@@ -38,4 +38,3 @@ class StreamHub {
 
 		}
 }
-


### PR DESCRIPTION
I made a mistake when adding the signalr group. I forgot to pass the group name when doing reconnect.
This is probably the reason the you widgets stops updating when restarting the server 