### PR TITLE
Moar Async

### DIFF
--- a/Fritz.Chatbot/Commands/UptimeCommand.cs
+++ b/Fritz.Chatbot/Commands/UptimeCommand.cs
@@ -23,9 +23,10 @@ namespace Fritz.Chatbot.Commands
 				return;
 			}
 
-			if (svc.Uptime.HasValue)
+			var uptime = await svc.Uptime();
+			if (uptime.HasValue)
 			{
-				await ChatService.SendMessageAsync($"The stream has been up for {svc.Uptime.Value.ToString(@"hh\:mm\:ss")}");
+				await ChatService.SendMessageAsync($"The stream has been up for {uptime.Value.ToString(@"hh\:mm\:ss")}");
 			}
 			else
 			{

--- a/Fritz.Chatbot/FritzBot.cs
+++ b/Fritz.Chatbot/FritzBot.cs
@@ -93,7 +93,7 @@ namespace Fritz.StreamTools.Services
 		{
 			foreach (var chat in _chatServices)
 			{
-				chat.ChatMessage += Chat_ChatMessage;
+				chat.ChatMessage += OnChat_ChatMessage;
 				chat.UserJoined += Chat_UserJoined;
 				chat.UserLeft += Chat_UserLeft;
 			}
@@ -104,7 +104,7 @@ namespace Fritz.StreamTools.Services
 		{
 			foreach (var chat in _chatServices)
 			{
-				chat.ChatMessage -= Chat_ChatMessage;
+				chat.ChatMessage -= OnChat_ChatMessage;
 				chat.UserJoined -= Chat_UserJoined;
 				chat.UserLeft -= Chat_UserLeft;
 			}
@@ -113,9 +113,22 @@ namespace Fritz.StreamTools.Services
 
 		#endregion
 
-		private async void Chat_ChatMessage(object sender, ChatMessageEventArgs e)
+		private async void OnChat_ChatMessage(object sender, ChatMessageEventArgs e)
 		{
+			// async void as Event callback
+			try
+			{
+				await Chat_ChatMessage(sender, e);
+			}
+			catch (Exception ex)
+			{
+				// Don't let exception escape from async void
+				_logger.LogError($"{DateTime.UtcNow}: Chat_ChatMessage - Error {Environment.NewLine}{ex}");
+			}
+		}
 
+	  private async Task Chat_ChatMessage(object sender, ChatMessageEventArgs e)
+	  {
 			// message is empty OR message doesn't start with ! AND doesn't end with ?
 
 			if (e.Message.EndsWith("?"))

--- a/Fritz.StreamLib.Core/Fritz.StreamLib.Core.csproj
+++ b/Fritz.StreamLib.Core/Fritz.StreamLib.Core.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+  </ItemGroup>
+
 </Project>

--- a/Fritz.StreamLib.Core/IStreamService.cs
+++ b/Fritz.StreamLib.Core/IStreamService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Fritz.StreamLib.Core
 {
@@ -12,7 +13,7 @@ namespace Fritz.StreamLib.Core
 
 		int CurrentViewerCount { get; }
 
-		TimeSpan? Uptime { get; }
+		ValueTask<TimeSpan?> Uptime();
 
 		/// <summary>
 		/// Event raised when the number of Followers or Viewers changes

--- a/Fritz.StreamTools/Pages/TestTwitchbot.cshtml.cs
+++ b/Fritz.StreamTools/Pages/TestTwitchbot.cshtml.cs
@@ -34,17 +34,17 @@ namespace Fritz.StreamTools.Pages
 
 		public TimeSpan? Uptime { get; set; }
 
-		public void OnGet()
+		public async Task OnGet()
 		{
 
 			var sw = Stopwatch.StartNew();
-			Uptime = TwitchProxy.Uptime;
+			Uptime = await TwitchProxy.Uptime();
 			this.Logger.LogInformation($"Get uptime took {sw.ElapsedMilliseconds}ms");
 
 			sw.Restart();
 			var api = new TwitchLib.TwitchAPI(clientId: "t7y5txan5q662t7zj7p3l4wlth8zhv");
 			var v5Stream = new TwitchLib.Streams.V5(api);
-			var myStream = v5Stream.GetStreamByUserAsync("96909659").GetAwaiter().GetResult();
+			var myStream = await v5Stream.GetStreamByUserAsync("96909659");
 			var createdAt = myStream.Stream?.CreatedAt;
 			this.Logger.LogInformation($"Get uptime took {sw.ElapsedMilliseconds}ms");
 

--- a/Fritz.StreamTools/Services/FakeService.cs
+++ b/Fritz.StreamTools/Services/FakeService.cs
@@ -38,7 +38,7 @@ namespace Fritz.StreamTools.Services
 
 		public int CurrentViewerCount => _numberOfViewers;
 
-		public TimeSpan? Uptime => null;
+		public ValueTask<TimeSpan?> Uptime() => new ValueTask<TimeSpan?>((TimeSpan?)null);
 
 		public event EventHandler<ServiceUpdatedEventArgs> Updated;
 

--- a/Fritz.StreamTools/Services/MixerService.cs
+++ b/Fritz.StreamTools/Services/MixerService.cs
@@ -122,10 +122,7 @@ namespace Fritz.StreamTools.Services
 		/// NOTE: This will hit the REST API when cached value expires
 		/// Will be null if stream is offline
 		/// </summary>
-		public TimeSpan? Uptime
-		{
-			get => _Mixer.GetUptime();
-		}
+		public ValueTask<TimeSpan?> Uptime() => new ValueTask<TimeSpan?>(_Mixer.GetUptime());
 
 		public void Dispose()
 		{

--- a/Fritz.StreamTools/Services/StreamService.cs
+++ b/Fritz.StreamTools/Services/StreamService.cs
@@ -48,7 +48,7 @@ namespace Fritz.StreamTools.Services
 			}
 		}
 
-		public TimeSpan? Uptime => null;
+		public ValueTask<TimeSpan?> Uptime() => new ValueTask<TimeSpan?>((TimeSpan?)null);
 
 		public event EventHandler<ServiceUpdatedEventArgs> Updated
 		{

--- a/Fritz.StreamTools/Services/TwitchService.cs
+++ b/Fritz.StreamTools/Services/TwitchService.cs
@@ -67,19 +67,11 @@ namespace Fritz.StreamTools.Services
 
 		public string Name { get { return "Twitch"; } }
 
-		public TimeSpan? Uptime
-		{
-			get
-			{
-
-				return Proxy.Uptime;
-
-			}
-		}
+		public ValueTask<TimeSpan?> Uptime() => Proxy.Uptime();
 
 		public bool IsAuthenticated => true;
 
-		private Task StartTwitchMonitoring()
+		private async Task StartTwitchMonitoring()
 		{
 
 			_ChatClient.Connected += (c, args) => Logger.LogInformation("Now connected to Twitch Chat");
@@ -87,17 +79,15 @@ namespace Fritz.StreamTools.Services
 			_ChatClient.UserJoined += _ChatClient_UserJoined;
 			_ChatClient.Init();
 
-			_CurrentFollowerCount = Proxy.GetFollowerCount();
+			_CurrentFollowerCount = await Proxy.GetFollowerCountAsync();
 			Proxy.NewFollowers += Proxy_NewFollowers;
 			Proxy.WatchFollowers(10000);
 
-			_CurrentViewerCount = Proxy.GetViewerCount();
+			_CurrentViewerCount = await Proxy.GetViewerCountAsync();
 			Proxy.NewViewers += Proxy_NewViewers;
 			Proxy.WatchViewers();
 
 			Logger.LogInformation($"Now monitoring Twitch with {_CurrentFollowerCount} followers and {_CurrentViewerCount} Viewers");
-
-			return Task.CompletedTask;
 
 		}
 

--- a/Fritz.Twitch/Proxy.cs
+++ b/Fritz.Twitch/Proxy.cs
@@ -183,18 +183,22 @@ namespace Fritz.Twitch
 			{
 				// Turn off timer, in case runs longer than interval
 				_FollowersTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-
-				// async void as TimerCallback delegate
-				var foundFollowerCount = await GetFollowerCountAsync();
-				if (foundFollowerCount != _WatchedFollowerCount)
+				try
 				{
-					_WatchedFollowerCount = foundFollowerCount;
-					NewFollowers?.Invoke(this, new NewFollowersEventArgs(foundFollowerCount));
+					var foundFollowerCount = await GetFollowerCountAsync();
+					if (foundFollowerCount != _WatchedFollowerCount)
+					{
+						_WatchedFollowerCount = foundFollowerCount;
+						NewFollowers?.Invoke(this, new NewFollowersEventArgs(foundFollowerCount));
+					}
+				}
+				finally
+				{
+					// Turn on timer
+					var intervalMs = Math.Max(1000, _WatchFollowersIntervalMs);
+					_FollowersTimer?.Change(intervalMs, intervalMs);
 				}
 
-				// Turn on timer
-				var intervalMs = Math.Max(1000, _WatchFollowersIntervalMs);
-				_FollowersTimer?.Change(intervalMs, intervalMs);
 			}
 			catch (Exception ex)
 			{
@@ -218,19 +222,22 @@ namespace Fritz.Twitch
 			{
 				// Turn off timer, in case runs longer than interval
 				_ViewersTimer?.Change(Timeout.Infinite, Timeout.Infinite);
-
-				var foundViewerCount = await GetViewerCountAsync();
-				if (foundViewerCount != _WatchedViewerCount)
+				try
 				{
-
-					_WatchedViewerCount = foundViewerCount;
-					NewViewers?.Invoke(this, new NewViewersEventArgs(foundViewerCount));
-
+					var foundViewerCount = await GetViewerCountAsync();
+					if (foundViewerCount != _WatchedViewerCount)
+					{
+						_WatchedViewerCount = foundViewerCount;
+						NewViewers?.Invoke(this, new NewViewersEventArgs(foundViewerCount));
+					}
+				}
+				finally
+				{
+					// Turn on timer
+					var intervalMs = Math.Max(1000, _WatchViewersIntervalMs);
+					_ViewersTimer?.Change(intervalMs, intervalMs);
 				}
 
-				// Turn on timer
-				var intervalMs = Math.Max(1000, _WatchViewersIntervalMs);
-				_ViewersTimer?.Change(intervalMs, intervalMs);
 			}
 			catch(Exception ex)
 			{

--- a/Fritz.Twitch/Proxy.cs
+++ b/Fritz.Twitch/Proxy.cs
@@ -3,10 +3,8 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,21 +14,30 @@ namespace Fritz.Twitch
 	public class Proxy : IDisposable
 	{
 
+		private const int MAX_QUEUED = 5;
 		public const string LOGGER_CATEGORY = "Fritz.Twitch";
 
 		private ConfigurationSettings Settings { get; }
 
+		private object _QueueLock = new object();
+		private int _QueuedRequests = 0;
+		private int _WaitingRequests = 0;
 		private static short _RateLimitRemaining = 1;
-		private static DateTime _RateLimitReset = DateTime.MaxValue;
+		// Ticks as Volatile.Write doesn't work for DateTime
+		private static long _RateLimitResetTicks = DateTime.MaxValue.Ticks;
 		private readonly static SemaphoreSlim _RateLimitLock = new SemaphoreSlim(1);
 
 		private static StreamData _CurrentStreamData;
-		private static DateTime _CurrentStreamLastFetchUtc;
+		// Ticks as Volatile.Write doesn't work for DateTime
+		private static long _CurrentStreamLastFetchUtcTicks;
 		private Timer _FollowersTimer;
 		private int _WatchedFollowerCount;
 		private int _WatchedViewerCount;
 		private Timer _ViewersTimer;
 		private readonly static SemaphoreSlim _CurrentStreamLock = new SemaphoreSlim(1);
+
+		private int _WatchViewersIntervalMs;
+		private int _WatchFollowersIntervalMs;
 
 		private ILogger Logger { get; }
 		internal HttpClient Client { get; private set; }
@@ -71,32 +78,73 @@ namespace Fritz.Twitch
 
 		private async Task<HttpResponseMessage> GetFromEndpoint(string url)
 		{
+			await WaitForSlot();
 
-			// Check rate-limit
+			HttpResponseMessage result;
 			await _RateLimitLock.WaitAsync();
-			if (_RateLimitRemaining <= 0)
+			try
+			{
+				result = await Client.GetAsync(url);
+
+				var remaining = short.Parse(result.Headers.GetValues("RateLimit-Remaining").First());
+				var reset = long.Parse(result.Headers.GetValues("RateLimit-Reset").First());
+
+				lock (_QueueLock)
+				{
+					_RateLimitRemaining = remaining;
+					_WaitingRequests--;
+					Volatile.Write(ref _RateLimitResetTicks, reset.ToDateTime().Ticks);
+				}
+				Logger.LogTrace($"{DateTime.UtcNow}: Twitch Rate - {remaining} until {reset.ToDateTime()}");
+			}
+			finally
 			{
 				_RateLimitLock.Release();
-				await Task.Delay(_RateLimitReset.Subtract(DateTime.UtcNow));
-				return await GetFromEndpoint(url);
 			}
-			_RateLimitLock.Release();
-
-			var result = await Client.GetAsync(url);
-
-			var remaining = short.Parse(result.Headers.GetValues("RateLimit-Remaining").First());
-			var reset = long.Parse(result.Headers.GetValues("RateLimit-Reset").First());
-
-			await _RateLimitLock.WaitAsync();
-			_RateLimitRemaining = remaining;
-			_RateLimitReset = reset.ToDateTime();
-			Logger.LogTrace($"{DateTime.UtcNow}: Twitch Rate - {remaining} until {_RateLimitReset}");
-			_RateLimitLock.Release();
 
 			result.EnsureSuccessStatusCode();
 
 			return result;
 
+		}
+
+		private async Task WaitForSlot()
+		{
+			var isQueued = false;
+			do
+			{
+				// Check rate-limit
+				lock (_QueueLock)
+				{
+					if (_RateLimitRemaining - _WaitingRequests > 0)
+					{
+						_WaitingRequests++;
+						if (isQueued)
+						{
+							_QueuedRequests--;
+							isQueued = false;
+						}
+					}
+					else
+					{
+						if (!isQueued)
+						{
+							if (_QueuedRequests + 1 > MAX_QUEUED)
+							{
+								throw new TimeoutException("Too many requests waiting");
+							}
+							_QueuedRequests++;
+							isQueued = true;
+						}
+					}
+				}
+
+				if (isQueued)
+				{
+					await Task.Delay(new DateTime(Volatile.Read(ref _RateLimitResetTicks)).Subtract(DateTime.UtcNow));
+				}
+			}
+			while (isQueued);
 		}
 
 		public async Task<int> GetFollowerCountAsync()
@@ -109,12 +157,6 @@ namespace Fritz.Twitch
 			Logger.LogTrace($"Response from Twitch GetFollowerCount: '{resultString}'");
 
 			return ParseFollowerResult(resultString);
-
-		}
-
-		public int GetFollowerCount()
-		{
-			return GetFollowerCountAsync().GetAwaiter().GetResult();
 		}
 
 		public async Task<int> GetViewerCountAsync()
@@ -125,45 +167,75 @@ namespace Fritz.Twitch
 
 		}
 
-		public int GetViewerCount()
-		{
-			return GetViewerCountAsync().GetAwaiter().GetResult();
-		}
-
 		public void WatchFollowers(int intervalMs = 5000)
 		{
+			_WatchFollowersIntervalMs = intervalMs;
+			_FollowersTimer?.Dispose();
 
 			_FollowersTimer = new Timer(OnWatchFollowers, null, 0, intervalMs);
 
 		}
 
-		private void OnWatchFollowers(object state)
+		private async void OnWatchFollowers(object state)
 		{
-
-			var foundFollowerCount = GetFollowerCount();
-			if (foundFollowerCount != _WatchedFollowerCount)
+			// async void as TimerCallback delegate
+			try
 			{
-				_WatchedFollowerCount = foundFollowerCount;
-				NewFollowers?.Invoke(this, new NewFollowersEventArgs(foundFollowerCount));
-			}
+				// Turn off timer, in case runs longer than interval
+				_FollowersTimer?.Change(Timeout.Infinite, Timeout.Infinite);
 
+				// async void as TimerCallback delegate
+				var foundFollowerCount = await GetFollowerCountAsync();
+				if (foundFollowerCount != _WatchedFollowerCount)
+				{
+					_WatchedFollowerCount = foundFollowerCount;
+					NewFollowers?.Invoke(this, new NewFollowersEventArgs(foundFollowerCount));
+				}
+
+				// Turn on timer
+				var intervalMs = Math.Max(1000, _WatchFollowersIntervalMs);
+				_FollowersTimer?.Change(intervalMs, intervalMs);
+			}
+			catch (Exception ex)
+			{
+				// Don't let exception escape from async void
+				Logger.LogError($"{DateTime.UtcNow}: OnWatchFollowers - Error {Environment.NewLine}{ex}");
+			}
 		}
 
 		public void WatchViewers(int intervalMs = 5000)
 		{
+			_WatchViewersIntervalMs = intervalMs;
+			_ViewersTimer?.Dispose();
+
 			_ViewersTimer = new Timer(OnWatchViewers, null, 0, intervalMs);
 		}
 
-		private void OnWatchViewers(object state)
+		private async void OnWatchViewers(object state)
 		{
-
-			var foundViewerCount = GetViewerCount();
-			if (foundViewerCount != _WatchedViewerCount)
+			// async void as TimerCallback delegate
+			try
 			{
+				// Turn off timer, in case runs longer than interval
+				_ViewersTimer?.Change(Timeout.Infinite, Timeout.Infinite);
 
-				_WatchedViewerCount = foundViewerCount;
-				NewViewers?.Invoke(this, new NewViewersEventArgs(foundViewerCount));
+				var foundViewerCount = await GetViewerCountAsync();
+				if (foundViewerCount != _WatchedViewerCount)
+				{
 
+					_WatchedViewerCount = foundViewerCount;
+					NewViewers?.Invoke(this, new NewViewersEventArgs(foundViewerCount));
+
+				}
+
+				// Turn on timer
+				var intervalMs = Math.Max(1000, _WatchViewersIntervalMs);
+				_ViewersTimer?.Change(intervalMs, intervalMs);
+			}
+			catch(Exception ex)
+			{
+				// Don't let exception escape from async void
+				Logger.LogError($"{DateTime.UtcNow}: OnWatchViewers - Error {Environment.NewLine}{ex}");
 			}
 
 		}
@@ -171,49 +243,43 @@ namespace Fritz.Twitch
 		/// <summary>
 		/// Return the duration that the current stream as been airing.  If not currently broadcasting, returns null
 		/// </summary>
-		public TimeSpan? Uptime
+		public async ValueTask<TimeSpan?> Uptime()
 		{
-			get
+			var startedAt = (await GetStreamAsync())?.StartedAt;
+			if (startedAt.HasValue)
 			{
-				var startedAt = GetStreamAsync().GetAwaiter().GetResult()?.StartedAt;
-				if (startedAt.HasValue)
-				{
-					return DateTime.UtcNow.Subtract(startedAt.Value);
-				}
-				return null;
+				return DateTime.UtcNow.Subtract(startedAt.Value);
 			}
+			return null;
 		}
 
 		public async Task<StreamData> GetStreamAsync()
 		{
-
-			await _CurrentStreamLock.WaitAsync();
-			if (DateTime.UtcNow.Subtract(_CurrentStreamLastFetchUtc) <= TimeSpan.FromSeconds(5) && _CurrentStreamData != null)
+			if (DateTime.UtcNow.Subtract(new DateTime(Volatile.Read(ref _CurrentStreamLastFetchUtcTicks))) <= TimeSpan.FromSeconds(5) && _CurrentStreamData != null)
 			{
-				var outData = _CurrentStreamData;
-				_CurrentStreamLock.Release();
-				return outData;
+				return Volatile.Read(ref _CurrentStreamData);
 			}
 
-			_CurrentStreamLock.Release();
 			if (await _CurrentStreamLock.WaitAsync(5000))
 			{
+				try
+				{
+					var url = $"/helix/streams?user_login={Settings.ChannelName}";
+					var result = await GetFromEndpoint(url);
 
-				var url = $"/helix/streams?user_login={Settings.ChannelName}";
-				var result = GetFromEndpoint(url).GetAwaiter().GetResult();
+					var resultString = await result.Content.ReadAsStringAsync();
+					Logger.LogTrace($"Response from Twitch GetStream: '{resultString}'");
 
-				var resultString = await result.Content.ReadAsStringAsync();
-				Logger.LogTrace($"Response from Twitch GetStream: '{resultString}'");
-
-				_CurrentStreamData = ParseStreamResult(resultString);
-				_CurrentStreamLastFetchUtc = DateTime.UtcNow;
-
-				_CurrentStreamLock.Release();
-
+					Volatile.Write(ref _CurrentStreamData, ParseStreamResult(resultString));
+					Volatile.Write(ref _CurrentStreamLastFetchUtcTicks, DateTime.UtcNow.Ticks);
+				}
+				finally
+				{
+					_CurrentStreamLock.Release();
+				}
 			}
 
-			return _CurrentStreamData;
-
+			return Volatile.Read(ref _CurrentStreamData);
 		}
 
 		internal static int ParseFollowerResult(string twitchString)

--- a/Test/Twitch/Chat/OnConnect.cs
+++ b/Test/Twitch/Chat/OnConnect.cs
@@ -32,17 +32,17 @@ namespace Test.Twitch.Chat
 
 
 		[Fact(Skip ="Need OAuth Token")]
-		public void ShouldWork()
+		public async Task ShouldWork()
 		{
 
 			var sut = new ChatClient(_Settings, new XUnitLogger(OutputHelper));
 			sut.Init();
 
-			Task.Delay(1000);
+			await Task.Delay(1000);
 
 			// sut.WhisperMessage("Hello from your bot", "csharpfritz");
 
-			Task.Delay(1000).GetAwaiter().GetResult();
+			await Task.Delay(1000);
 			sut.Dispose();
 
 		}

--- a/Test/Twitch/Proxy/GetFollowerCount.cs
+++ b/Test/Twitch/Proxy/GetFollowerCount.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Fritz.Twitch;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
@@ -44,14 +45,14 @@ namespace Test.Twitch.Proxy
 		public XUnitLogger Logger { get; }
 
 		[Fact]
-		public void ShouldReturnNonZeroCount()
+		public async Task ShouldReturnNonZeroCount()
 		{
 
 			// Arrange
 			var sut = new Fritz.Twitch.Proxy(_Client, _Settings, Logger);
 
 			// Act
-			var followerCount = sut.GetFollowerCount();
+			var followerCount = await sut.GetFollowerCountAsync();
 			Output.WriteLine($"csharpfritz Twitch follower count: {followerCount}");
 
 			// Assert

--- a/Test/Twitch/Proxy/GetStreamData.cs
+++ b/Test/Twitch/Proxy/GetStreamData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Fritz.Twitch;
 using Xunit;
 using Xunit.Abstractions;
@@ -74,14 +75,14 @@ namespace Test.Twitch.Proxy
 		}
 
 		[Fact]
-		public void ShouldReturnZeroWhenNotStreaming()
+		public async Task ShouldReturnZeroWhenNotStreaming()
 		{
 
 			// Arrange
 			var sut = new Fritz.Twitch.Proxy(_Client, _Settings, Logger);
 
 			// Act
-			var viewerCount = sut.GetViewerCountAsync().GetAwaiter().GetResult();
+			var viewerCount = await sut.GetViewerCountAsync();
 			Output.WriteLine($"csharpfritz Twitch viewer count: {viewerCount}");
 
 			// Assert


### PR DESCRIPTION
`ReaderWriterLockSlim` doesn't switch threads; so if the running thread changes across an await it won't unlock the lock.

`SemaphoreSlim` is thread neutral so can still unlock if the running thread changes. As a bouns it also has an async method for waiting for the lock `WaitAsync`

Also remove synchronous/blocking waits from `.GetAwaiter().GetResult()` and use `async` and `await` instead.