### PR TITLE
Feat/docs user secrets

### DIFF
--- a/Fritz.StreamTools.sln
+++ b/Fritz.StreamTools.sln
@@ -11,7 +11,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fritz.StreamTools", "Fritz.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionFiles", "SolutionFiles", "{5119C9E8-5FEC-47D0-AE98-482BF4DFD1F6}"
 	ProjectSection(SolutionItems) = preProject
+		.dockerignore = .dockerignore
 		.editorconfig = .editorconfig
+		.gitattributes = .gitattributes
+		.gitignore = .gitignore
+		build.cmd = build.cmd
+		docker-compose.ci.build.yml = docker-compose.ci.build.yml
+		docker-compose.override.yml = docker-compose.override.yml
+		docker-compose.yml = docker-compose.yml
+		LICENSE = LICENSE
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StreamAnalytics", "StreamAnalytics\StreamAnalytics.csproj", "{65DF3EC8-34F7-4F02-B2F1-ECB65BC4B20E}"
@@ -20,7 +29,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fritz.StreamLib.Core", "Fri
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fritz.Chatbot", "Fritz.Chatbot\Fritz.Chatbot.csproj", "{3C9F654B-C862-4BAC-8254-6BE5B295A4B6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fritz.Twitch", "Fritz.Twitch\Fritz.Twitch.csproj", "{28D6D34A-3F6E-40B3-B62A-20F90D281C7D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fritz.Twitch", "Fritz.Twitch\Fritz.Twitch.csproj", "{28D6D34A-3F6E-40B3-B62A-20F90D281C7D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ The project supports reading stream metrics from the following services:
 
 This application was built with ASP.NET Core 2.0 and can be built on Mac, Linux, and Windows.  Download the [.NET SDK](https://dot.net) and grab a copy of [Visual Studio Code](https://code.visualstudio.com) to get started on any platform
 
+### Configuration
+
+#### Google Fonts Api
+
+To use your own Google Fonts Api key without modifying the `Fritz.StreamTools\appSettings.json` you can place your key in the `secrets.json` file in the [path appropriate for your OS](https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcore-2.1&tabs=visual-studio#how-the-secret-manager-tool-works).
+
+The *userSecretsId* is **78c713a0-80e0-4e16-956a-33cf16f08a02** and can be found in `Fritz.StreamTools\Fritz.StreamTools.csproj`.
+
+If you are using Visual Studio you can use the [integrated User Secrets management UI](https://blogs.msdn.microsoft.com/mihansen/2017/09/10/managing-secrets-in-net-core-2-0-apps/)
+
+The `secrets.json` file should look like this
+
+
+    {
+      "GoogleFontsApi": {
+        "Key": "<YOUR API KEY>"
+      }
+    }
+
+
 ### Naming guideline for unit tests:
 *  Create a folder for each "logical class"
 *  Create a test class for each feature to test - end with "Should"


### PR DESCRIPTION
I had to do a little research to figure out how to set up my local secrets for the Google Fonts Api key, so I added some instructions and links to the `README.md`

In other projects I've worked on I've found it helpful to include root repository files in my 'Solution Items' folder to make them easy to find and edit in VS. I wanted to update the `README.md` so I added it to that folder (along with the other editable solution level files.

Finally the project guid in the solution file was outdated for `Fritz.Twitch`. It was using the old guid and VS wanted me to replace it with the new one. See https://github.com/dotnet/project-system/issues/3079#issuecomment-354180353