### PR TITLE
Feat/google fonts module

### DIFF
--- a/Fritz.StreamTools/Views/Followers/GoalConfiguration.cshtml
+++ b/Fritz.StreamTools/Views/Followers/GoalConfiguration.cshtml
@@ -94,8 +94,6 @@
 
 @section scripts {
 		<script>
-			const GoogleFontsApiKey = '@ViewBag.GoogleFontsApiKey';	
-
 			const ConfigurationModel = {
 				Caption: "@nameof(Model.Caption)",
 				Goal: "@nameof(Model.Goal)",
@@ -125,6 +123,18 @@
 		<environment exclude="Development">
 			<script src="/js/GoalConfiguration.min.js" asp-append-version="true"></script>
 		</environment>
+
+		<script>
+			(function (window) {
+				'use strict';
+
+				const moduleConfig = {
+					googleFontsApiKey: '@ViewBag.GoogleFontsApiKey'
+				};
+
+				window.fontsModule.initModule(moduleConfig);
+			}(window))
+		</script>
 	}
 
 @section styles {

--- a/Fritz.StreamTools/wwwroot/js/GoalConfiguration/GoalConfiguration.js
+++ b/Fritz.StreamTools/wwwroot/js/GoalConfiguration/GoalConfiguration.js
@@ -1,7 +1,9 @@
 var isLoadingFromStorage = false;
 
-(function () {
-	'use strict'; //
+(function (window) {
+  'use strict';
+
+  const fontsModule = window.fontsModule;
 
 	document.getElementById('fontsPanel').style.display = 'none';
 
@@ -21,13 +23,9 @@ var isLoadingFromStorage = false;
 			var key = localStorage.key(i);
 			const item = localStorage.getItem(key);
 
+			// Handled in GoogleFonts.js
 			if (key === 'supportedFonts') {
-
-				log("setting supported fonts from local storage");
-				const fonts = JSON.parse(item);
-				setSupportedFonts(fonts);
 				continue;
-
 			}
 
 			log(key, item);
@@ -69,8 +67,6 @@ var isLoadingFromStorage = false;
 
 		}
 
-		InitGoogleFonts();
-
 		ConfigureDefaultFontColors();
 
 		$('[data-toggle="tooltip"]').tooltip();
@@ -79,24 +75,26 @@ var isLoadingFromStorage = false;
 
 	}
 
-})();
+})(window);
 
 
 function saveValues() {
+	// Prevent cached fonts from being cleared
+  const cachedFonts = JSON.parse(localStorage.getItem('supportedFonts'));
 
 	localStorage.clear();
 
-	const elements = Array.from(document.getElementsByTagName("input"));
+  const elements = Array.from(document.getElementsByTagName("input"));
+
 	for (let el of elements) {
 
 		log(`Saving value: ${el.id}: ${el.value}`);
 
 		localStorage.setItem(el.id, el.value);
 
-	}
+  }
 
-	localStorage.setItem('supportedFonts', JSON.stringify(supportedFonts));
-
+  localStorage.setItem('supportedFonts', JSON.stringify(cachedFonts));
 }
 
 // retrieve the supported font names from google api
@@ -178,8 +176,8 @@ document.getElementById(ConfigurationModel.FontName).onkeyup = function (d) {
 			d.keyCode > 90)
 	)
 		return;
-	document.getElementById('fontsPanel').style.display = '';
-	updateFontList(filterFontList(supportedFonts, this.value));
+  document.getElementById('fontsPanel').style.display = '';
+  updateFontList(filterFontList(window.fontsModule.getSupportedFonts(), this.value));
 
 };
 
@@ -247,7 +245,7 @@ function ConfigureDefaultFontColors() {
 		var thisButton = document.getElementById(button);
 		thisButton.onclick = function (event) {
 
-			event.preventDefault()
+		  event.preventDefault();
 
 			var targetColorEl = document.getElementById(this.getAttribute("data-target"));
 			var inspectColor = this.getAttribute("data-background");

--- a/Fritz.StreamTools/wwwroot/js/GoalConfiguration/GoogleFonts.js
+++ b/Fritz.StreamTools/wwwroot/js/GoalConfiguration/GoogleFonts.js
@@ -1,265 +1,71 @@
-var supportedFonts = [];
+(function (window) {
+  'use strict';
 
-function InitGoogleFonts() {
+  window.fontsModule = {
+		initModule: initModulePublic,
+		getSupportedFonts: getSupportedFontsPublic,
+		setSupportedFonts: setSupportedFontsPublic
+  };
 
-	if (GoogleFontsApiKey !== '' && supportedFonts.length === 0) {
+  let googleFontsApiKey = '';
+  let supportedFonts = [];
 
-		googleFontsAdapter(setSupportedFontsFromApi);
-	} else if (GoogleFontsApiKey === '') {
+  const defaultFonts = [ 'Arial', 'Helvetica', 'Times New Roman', 'Times', 'Courier New' ];
 
-		log('Setting base fonts');
-		setSupportedFontsFromApi(baseFontsAdapter());
-
-	}
-
-}
-
-function baseFontsAdapter() {
-
-	return [
-			{ 'family': 'Arial' },
-			{ 'family': 'Helvetica' },
-			{ 'family': 'Times New Roman' },
-			{ 'family': 'Times' },
-			{ 'family': 'Courier New' }
-	];
-
-}
-
-function googleFontsAdapter(setter) {
-	//Reference for the HTTP in vanilla JS https://www.sitepoint.com/guide-vanilla-ajax-without-jquery
-	let api = 'https://www.googleapis.com/webfonts/v1/webfonts?key=' + GoogleFontsApiKey;
-
-	if (!GoogleFontsApiKey) {
-		setter([{
-			'family': 'Abel'
-		}, {
-			'family': 'Abril Fatface'
-		}, {
-			'family': 'Acme'
-		}, {
-			'family': 'Alegreya'
-		}, {
-			'family': 'Alex Brush'
-		}, {
-			'family': 'Amaranth'
-		}, {
-			'family': 'Amatic SC'
-		}, {
-			'family': 'Anton'
-		}, {
-			'family': 'Arbutus Slab'
-		}, {
-			'family': 'Architects Daughter'
-		}, {
-			'family': 'Archivo'
-		}, {
-			'family': 'Archivo Black'
-		}, {
-			'family': 'Arima Madurai'
-		}, {
-			'family': 'Asap'
-		}, {
-			'family': 'Bad Script'
-		}, {
-			'family': 'Baloo Bhaina'
-		}, {
-			'family': 'Bangers'
-		}, {
-			'family': 'Berkshire Swash'
-		}, {
-			'family': 'Bitter'
-		}, {
-			'family': 'Boogaloo'
-		}, {
-			'family': 'Bree Serif'
-		}, {
-			'family': 'Bungee Shade'
-		}, {
-			'family': 'Cantata One'
-		}, {
-			'family': 'Catamaran'
-		}, {
-			'family': 'Caveat'
-		}, {
-			'family': 'Caveat Brush'
-		}, {
-			'family': 'Ceviche One'
-		}, {
-			'family': 'Chewy'
-		}, {
-			'family': 'Contrail One'
-		}, {
-			'family': 'Crete Round'
-		}, {
-			'family': 'Dancing Script'
-		}, {
-			'family': 'Exo 2'
-		}, {
-			'family': 'Fascinate'
-		}, {
-			'family': 'Francois One'
-		}, {
-			'family': 'Freckle Face'
-		}, {
-			'family': 'Fredoka One'
-		}, {
-			'family': 'Gloria Hallelujah'
-		}, {
-			'family': 'Gochi Hand'
-		}, {
-			'family': 'Great Vibes'
-		}, {
-			'family': 'Handlee'
-		}, {
-			'family': 'Inconsolata'
-		}, {
-			'family': 'Indie Flower'
-		}, {
-			'family': 'Kaushan Script'
-		}, {
-			'family': 'Lalezar'
-		}, {
-			'family': 'Lato'
-		}, {
-			'family': 'Libre Baskerville'
-		}, {
-			'family': 'Life Savers'
-		}, {
-			'family': 'Lobster'
-		}, {
-			'family': 'Lora'
-		}, {
-			'family': 'Luckiest Guy'
-		}, {
-			'family': 'Marcellus SC'
-		}, {
-			'family': 'Merriweather'
-		}, {
-			'family': 'Merriweather Sans'
-		}, {
-			'family': 'Monoton'
-		}, {
-			'family': 'Montserrat'
-		}, {
-			'family': 'News Cycle'
-		}, {
-			'family': 'Nothing You Could Do'
-		}, {
-			'family': 'Noto Serif'
-		}, {
-			'family': 'Oleo Script Swash Caps'
-		}, {
-			'family': 'Open Sans'
-		}, {
-			'family': 'Open Sans Condensed'
-		}, {
-			'family': 'Oranienbaum'
-		}, {
-			'family': 'Oswald'
-		}, {
-			'family': 'PT Sans'
-		}, {
-			'family': 'PT Sans Narrow'
-		}, {
-			'family': 'PT Serif'
-		}, {
-			'family': 'Pacifico'
-		}, {
-			'family': 'Patrick Hand'
-		}, {
-			'family': 'Peralta'
-		}, {
-			'family': 'Permanent Marker'
-		}, {
-			'family': 'Philosopher'
-		}, {
-			'family': 'Play'
-		}, {
-			'family': 'Playfair Display'
-		}, {
-			'family': 'Playfair Display SC'
-		}, {
-			'family': 'Poiret One'
-		}, {
-			'family': 'Press Start 2P'
-		}, {
-			'family': 'Prosto One'
-		}, {
-			'family': 'Quattrocento'
-		}, {
-			'family': 'Questrial'
-		}, {
-			'family': 'Quicksand'
-		}, {
-			'family': 'Raleway'
-		}, {
-			'family': 'Rancho'
-		}, {
-			'family': 'Righteous'
-		}, {
-			'family': 'Roboto'
-		}, {
-			'family': 'Roboto Condensed'
-		}, {
-			'family': 'Roboto Slab'
-		}, {
-			'family': 'Rubik'
-		}, {
-			'family': 'Rye'
-		}, {
-			'family': 'Satisfy'
-		}, {
-			'family': 'Shadows Into Light'
-		}, {
-			'family': 'Shojumaru'
-		}, {
-			'family': 'Sigmar One'
-		}, {
-			'family': 'Skranji'
-		}, {
-			'family': 'Slabo 27px'
-		}, {
-			'family': 'Special Elite'
-		}, {
-			'family': 'Tinos'
-		}, {
-			'family': 'Ultra'
-		}, {
-			'family': 'UnifrakturMaguntia'
-		}, {
-			'family': 'VT323'
-		}, {
-			'family': 'Yanone Kaffeesatz'
-		}]);
-		return;
-	}
-
-	let xhr = new XMLHttpRequest();
-	xhr.open('GET', api);
-	xhr.send(null);
-
-	log('Calling google fonts api');
-
-	xhr.onreadystatechange = function () {
-		let DONE = 4; // readyState 4 means the request is done.
-		let OK = 200; // status 200 is a successful return.
-		if (xhr.readyState === DONE) {
-			if (xhr.status === OK)
-				setter(JSON.parse(xhr.responseText).items); // 'This is the returned text.'
-			else
-				log('Error: ' + xhr.status); // An error occurred during the request.
+  function initModulePublic(moduleConfig) {
+		if (!moduleConfig.googleFontsApiKey) {
+			log('No Google Fonts Api key provided');
+		} else {
+			googleFontsApiKey = moduleConfig.googleFontsApiKey;
 		}
-	}
-}
 
-function setSupportedFonts(fonts) {
-	localStorage.setItem('supportedFonts', JSON.stringify(supportedFonts));
-	updateFontList(filterFontList(supportedFonts));
-}
+		const cachedFonts = JSON.parse(localStorage.getItem('supportedFonts'));
 
-function setSupportedFontsFromApi(fonts) {
-	supportedFonts = fonts.map((v) => v.family);
-	setSupportedFonts(supportedFonts);
-}
+		if (cachedFonts && Array.isArray(cachedFonts)) {
+			log(`Setting [${cachedFonts.length}] supported fonts from local storage`);
 
+			supportedFonts = cachedFonts;
+		  updateFontList(filterFontList(supportedFonts));
+		} else if (googleFontsApiKey) {
+			requestGoogleFonts();
+
+		} else {
+			useDefaultFonts();
+		}
+  }
+
+  function getSupportedFontsPublic() {
+		return supportedFonts;
+  }
+
+  function setSupportedFontsPublic(fonts) {
+		supportedFonts = fonts;
+
+		localStorage.setItem('supportedFonts', JSON.stringify(supportedFonts));
+		updateFontList(filterFontList(supportedFonts));
+  }
+	
+  function requestGoogleFonts() {
+		log('Requesting fonts list from google fonts api');
+
+	  const requestUrl = `https://www.googleapis.com/webfonts/v1/webfonts?key=${googleFontsApiKey}`;
+
+	  const request = new Request(requestUrl);
+
+	  fetch(request)
+		.then(response => response.json())
+		.then(responseData => responseData.items.map(v => v.family))
+		.then(fonts => setSupportedFontsPublic(fonts))
+		.catch(error => {
+		  log('Error requesting google fonts', error);
+
+		  useDefaultFonts();
+		});
+  }
+
+  function useDefaultFonts() {
+		log('Falling back to default fonts', defaultFonts);
+
+		setSupportedFontsPublic(defaultFonts);
+  }
+}(window));

--- a/Fritz.StreamTools/wwwroot/js/GoalConfiguration/Preview.js
+++ b/Fritz.StreamTools/wwwroot/js/GoalConfiguration/Preview.js
@@ -25,6 +25,8 @@ function loadPreview() {
 	const iframeWidth = document.getElementById("widgetPreview").clientWidth - 40;
 	const fontName = document.getElementById(ConfigurationModel.FontName).value;
 
+  const supportedFonts = window.fontsModule.getSupportedFonts();
+
 	if (supportedFonts.length > 0 && filterFontList(supportedFonts, fontName, filterExactMatchOperation).length !== 1) {
 		alert('Font not supported by Google Fonts');
 		return;


### PR DESCRIPTION
This is my attempt to implement the revealing module pattern I mentioned during the stream with `GoogleFonts.js`.

Everything in `GoogleFonts.js` is private by being wrapped in an [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE).

I expose functions I want in other parts of the app to have access to by naming them with a suffix of `Public` and assigning them to properties on the `fontsModule` object which is attached to `window` (making it globally accessible).

To kick off the module and load fonts (either by pulling them out of `localStorage`, making a request to the google fonts api or loading the `defaultFonts`) we make a call in `GoalConfiguration.cshtml` to `window.fontsModule.initModule()` passing the configuration needed by the module.

Anywhere in other javascript files that functions from `GoogleFonts.js` are needed we can access the public ones via `window.fontsModule.<functionName>()` or by assigning that module object to a local variable like

`const fontsModule = window.fontsModule;`

The supported fonts are accessible via setter/getter in the `fontsModule` and if all attempts to load fonts fail we fall back to the hardcoded fonts list in the module.

Also, I think I might have used some spaces instead of tabs so the diff probably shows more (significant)changes than there actually are.