### PR TITLE
Fix for DI registration problem with GithubService

### DIFF
--- a/Fritz.StreamTools/Controllers/GitHubController.cs
+++ b/Fritz.StreamTools/Controllers/GitHubController.cs
@@ -5,12 +5,8 @@ using Octokit;
 using System.Threading.Tasks;
 using System.Linq;
 using System;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Caching.Memory;
 using LazyCache;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
-using Services = Fritz.StreamTools.Services;
 using Fritz.StreamTools.Services;
 
 namespace Fritz.StreamTools.Controllers
@@ -20,7 +16,7 @@ namespace Fritz.StreamTools.Controllers
 		public GitHubController(
 			IAppCache cache,
 			GitHubRepository repository,
-			Services.GitHubClient client,
+			GithubyMcGithubFaceClient client,
 			ILogger<GitHubController> logger,
 			IOptions<GitHubConfiguration> githubConfiguration)
 		{
@@ -33,7 +29,7 @@ namespace Fritz.StreamTools.Controllers
 
 		public IAppCache Cache { get; }
 		public ILogger<GitHubController> Logger { get; }
-		public Services.GitHubClient Client { get; }
+		public GithubyMcGithubFaceClient Client { get; }
 
 		private readonly GitHubRepository _gitHubRepository;
 

--- a/Fritz.StreamTools/Hubs/GithubyMcGithubFace.cs
+++ b/Fritz.StreamTools/Hubs/GithubyMcGithubFace.cs
@@ -9,20 +9,13 @@ namespace Fritz.StreamTools.Hubs
 	/// So named because @rachelAppel said so..
 	public class GithubyMcGithubFace : BaseHub
 	{
-		public GitHubService GitHubService { get; }
 		public GitHubClient GitHubClient { get; }
 
 		public GithubyMcGithubFace(
-			GitHubService gitHubService,
 			GitHubClient client
 			)
 		{
-
-			this.GitHubService = gitHubService;
-			this.GitHubClient = client;  
-
-			GitHubService.Updated += Git_Updated;
-
+			this.GitHubClient = client;
 		}
 
 		private void Git_Updated(object sender, GitHubUpdatedEventArgs e)

--- a/Fritz.StreamTools/Hubs/GithubyMcGithubFace.cs
+++ b/Fritz.StreamTools/Hubs/GithubyMcGithubFace.cs
@@ -9,19 +9,19 @@ namespace Fritz.StreamTools.Hubs
 	/// So named because @rachelAppel said so..
 	public class GithubyMcGithubFace : BaseHub
 	{
-		public GitHubClient GitHubClient { get; }
+		public GithubyMcGithubFaceClient GithubyMcGithubFaceClient { get; }
 
 		public GithubyMcGithubFace(
-			GitHubClient client
+			GithubyMcGithubFaceClient client
 			)
 		{
-			this.GitHubClient = client;
+			this.GithubyMcGithubFaceClient = client;
 		}
 
 		private void Git_Updated(object sender, GitHubUpdatedEventArgs e)
 		{
 
-			this.GitHubClient.UpdateGitHub(e.Contributors);
+			this.GithubyMcGithubFaceClient.UpdateGitHub(e.Contributors);
 
 		}
 	}

--- a/Fritz.StreamTools/Models/GitHubRepository.cs
+++ b/Fritz.StreamTools/Models/GitHubRepository.cs
@@ -31,78 +31,71 @@ namespace Fritz.StreamTools.Models
 
 		private (string user, string repo)[] _Repositories = null;
 
-		public async Task<IEnumerable<GitHubInformation>> GetRecentContributors(string repositoryCsv) {
-
+		private async Task<List<GitHubInformation>> FetchContributersFromGithub(string repositoryCsv = "")
+		{
 			var outModel = new List<GitHubInformation>();
+			Logger.LogWarning("Fetching data from GitHub");
 
-			return await AppCache.GetOrAddAsync<List<GitHubInformation>>("GitHubData", async (x) => {
+		var repositories = GetRepositories(repositoryCsv);
+		var lastMonth = DateTimeOffset.Now.AddMonths(-1);
 
-				x.AbsoluteExpiration = DateTime.Now.AddMinutes(60);
-
-				Logger.LogWarning("Fetching data from GitHub");
-
-				var repositories = repositoryCsv.Split(',');
-				var lastMonth = DateTimeOffset.Now.AddMonths(-1);
-
-				foreach (var repo in repositories)
-				{
-
-					var thisRepo = repo.Split('/')[1];
-					var thisUser = repo.Split('/')[0];
-					var model = new GitHubInformation() { Repository = thisRepo };
-
-					IReadOnlyList<Contributor> contributors;
-
-					try {
-						contributors =
-							await Client.Repository.Statistics.GetContributors(thisUser, thisRepo);
-					}
-					catch (RateLimitExceededException) {
-						// do nothing... return empty collection
-						return outModel;
-					}
-					model.TopEverContributors.AddRange(
-									contributors.Where(c => c.Total > 0 && c.Author.Login != Configuration.ExcludeUser)
-															.OrderByDescending(c => c.Total)
-															.Take(5)
-															.Select(c => new GitHubContributor()
-															{
-																Author = c.Author.Login,
-																Commits = c.Total
-															}));
-
-					model.TopMonthContributors.AddRange(
-									contributors.OrderByDescending(c => c.Weeks.Where(w => w.Week >= lastMonth)
-																															.Sum(e => e.Commits))
-															.Select(c => new GitHubContributor
-															{
-																Author = c.Author.Login,
-																Commits = c.Weeks.Where(w => w.Week >= lastMonth)
-																															.Sum(e => e.Commits)
-															})
-															.Where(c => c.Commits > 0 && c.Author != Configuration.ExcludeUser)
-															.OrderByDescending(c => c.Commits)
-															.Take(5));
-
-					model.TopWeekContributors.AddRange(
-									contributors.Where(c => c.Weeks.Last().Commits > 0)
-															.Select(c => new GitHubContributor
-															{
-																Author = c.Author.Login,
-																Commits = c.Weeks.Last().Commits
-															})
-															.Where(c => c.Commits > 0 && c.Author != Configuration.ExcludeUser)
-															.OrderByDescending(c => c.Commits)
-															.Take(5));
-
-					outModel.Add(model);
-
-				}
-
+		foreach (var (user, repo) in repositories)
+	  {
+			var model = new GitHubInformation() { Repository = repo };
+			IReadOnlyList<Contributor> contributors;
+			try
+			{
+				contributors =
+			  await Client.Repository.Statistics.GetContributors(user, repo);
+			}
+			catch (RateLimitExceededException)
+			{
+			// do nothing... return empty collection
 				return outModel;
+			}
+			model.TopEverContributors.AddRange(
+				contributors.Where(c => c.Total > 0 && c.Author.Login != Configuration.ExcludeUser)
+										.OrderByDescending(c => c.Total)
+										.Take(5)
+										.Select(c => new GitHubContributor()
+										{
+										  Author = c.Author.Login,
+										  Commits = c.Total
+										}));
+			model.TopMonthContributors.AddRange(
+						contributors.OrderByDescending(c => c.Weeks.Where(w => w.Week >= lastMonth)
+																												.Sum(e => e.Commits))
+												.Select(c => new GitHubContributor
+												{
+												  Author = c.Author.Login,
+												  Commits = c.Weeks.Where(w => w.Week >= lastMonth)
+																												.Sum(e => e.Commits)
+												})
+												.Where(c => c.Commits > 0 && c.Author != Configuration.ExcludeUser)
+												.OrderByDescending(c => c.Commits)
+												.Take(5));
+			model.TopWeekContributors.AddRange(
+						contributors.Where(c => c.Weeks.Last().Commits > 0)
+												.Select(c => new GitHubContributor
+												{
+												  Author = c.Author.Login,
+												  Commits = c.Weeks.Last().Commits
+												})
+												.Where(c => c.Commits > 0 && c.Author != Configuration.ExcludeUser)
+												.OrderByDescending(c => c.Commits)
+												.Take(5));
+			outModel.Add(model);
+		}
+		return outModel;
+	}
 
+		public async Task<IEnumerable<GitHubInformation>> GetRecentContributors(string repositoryCsv)
+		{
+			return await AppCache.GetOrAddAsync<List<GitHubInformation>>("GitHubData", async (x) =>
+			{
+				x.AbsoluteExpiration = DateTime.Now.AddMinutes(60);
+				return await FetchContributersFromGithub(repositoryCsv);
 			});
-
 		}
 
 		public static DateTime LastUpdate = DateTime.MinValue;
@@ -115,9 +108,8 @@ namespace Fritz.StreamTools.Models
 				x.AbsoluteExpiration = DateTime.UtcNow.AddMinutes(1);
 
 				var thisLastUpdate = DateTime.MinValue;
-				var repositories = GetRepositories(repositoryCsv);
 
-				foreach (var r in repositories)
+				foreach (var r in GetRepositories(repositoryCsv))
 				{
 
 					Logger.LogInformation($"Getting GitHub last update information for {r}");

--- a/Fritz.StreamTools/Models/GitHubRepository.cs
+++ b/Fritz.StreamTools/Models/GitHubRepository.cs
@@ -89,12 +89,12 @@ namespace Fritz.StreamTools.Models
 		return outModel;
 	}
 
-		public async Task<IEnumerable<GitHubInformation>> GetRecentContributors(string repositoryCsv)
+		public async Task<IEnumerable<GitHubInformation>> GetRecentContributors(string repositoryCsv = "")
 		{
-			return await AppCache.GetOrAddAsync<List<GitHubInformation>>("GitHubData", async (x) =>
+			return await AppCache.GetOrAddAsync<List<GitHubInformation>>("GitHubData", x =>
 			{
 				x.AbsoluteExpiration = DateTime.Now.AddMinutes(60);
-				return await FetchContributersFromGithub(repositoryCsv);
+				return FetchContributersFromGithub(repositoryCsv);
 			});
 		}
 
@@ -132,7 +132,7 @@ namespace Fritz.StreamTools.Models
 
 		}
 
-		private (string user, string repo)[] GetRepositories(string repositoryCsv)
+		private (string user, string repo)[] GetRepositories(string repositoryCsv = "")
 		{
 
 			if (_Repositories != null)

--- a/Fritz.StreamTools/Services/GitHubService.cs
+++ b/Fritz.StreamTools/Services/GitHubService.cs
@@ -41,7 +41,7 @@ namespace Fritz.StreamTools.Services
 		  using (var scope = Services.CreateScope())
 		  {
 			  var repo = scope.ServiceProvider.GetService(typeof(GitHubRepository)) as GitHubRepository;
-			  var githubClient = scope.ServiceProvider.GetService(typeof(GitHubClient)) as GitHubClient;
+			  var mcGithubFaceClient = scope.ServiceProvider.GetService(typeof(GithubyMcGithubFaceClient)) as GithubyMcGithubFaceClient;
 				while (!cancellationToken.IsCancellationRequested)
 			  {
 				  if (repo != null)
@@ -55,7 +55,7 @@ namespace Fritz.StreamTools.Services
 						  var newInfo = new GitHubInformation[] { };
 
 						  Logger.LogWarning($"Triggering refresh of GitHub scoreboard with updates as of {lastUpdate}");
-						  githubClient?.UpdateGitHub(newInfo);
+						  mcGithubFaceClient?.UpdateGitHub(newInfo);
 					  }
 				  }
 				  await Task.Delay(500, cancellationToken);

--- a/Fritz.StreamTools/Services/GitHubService.cs
+++ b/Fritz.StreamTools/Services/GitHubService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Fritz.StreamTools.Models;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -24,8 +25,6 @@ namespace Fritz.StreamTools.Services
 		public IServiceProvider Services { get; }
 		public ILogger<GitHubService> Logger { get; }
 
-		public event EventHandler<GitHubUpdatedEventArgs> Updated = null;
-
 		public Task StartAsync(CancellationToken cancellationToken)
 		{
 			return MonitorUpdates(cancellationToken);
@@ -38,39 +37,30 @@ namespace Fritz.StreamTools.Services
 
 		private async Task MonitorUpdates(CancellationToken cancellationToken)
 		{
-
 			var lastRequest = DateTime.Now;
+		  using (var scope = Services.CreateScope())
+		  {
+			  var repo = scope.ServiceProvider.GetService(typeof(GitHubRepository)) as GitHubRepository;
+			  var githubClient = scope.ServiceProvider.GetService(typeof(GitHubClient)) as GitHubClient;
+				while (!cancellationToken.IsCancellationRequested)
+			  {
+				  if (repo != null)
+				  {
+					  var lastUpdate = await repo.GetLastCommitTimestamp();
+					  if (lastUpdate > LastUpdate)
+					  {
 
-			while (!cancellationToken.IsCancellationRequested)
-			{
+						  LastUpdate = lastUpdate;
 
-				var lastUpdate = await GetLastCommittedTimestamp();
-				if (lastUpdate > LastUpdate)
-				{
+						  var newInfo = new GitHubInformation[] { };
 
-					LastUpdate = lastUpdate;
-
-					var newInfo = new GitHubInformation[] { };
-
-					Logger.LogWarning($"Triggering refresh of GitHub scoreboard with updates as of {lastUpdate}");
-					Updated?.Invoke(this, new GitHubUpdatedEventArgs(newInfo, lastUpdate));
-
-				}
-				await Task.Delay(500);
-
-			}
-
+						  Logger.LogWarning($"Triggering refresh of GitHub scoreboard with updates as of {lastUpdate}");
+						  githubClient?.UpdateGitHub(newInfo);
+					  }
+				  }
+				  await Task.Delay(500, cancellationToken);
+			  }
+		  }
 		}
-
-		private async Task<DateTime> GetLastCommittedTimestamp()
-		{
-
-			var repo = Services.GetService(typeof(GitHubRepository)) as GitHubRepository;
-
-			return await repo.GetLastCommitTimestamp();
-
-
-		}
-
 	}
 }

--- a/Fritz.StreamTools/Services/GithubyMcGithubFaceClient.cs
+++ b/Fritz.StreamTools/Services/GithubyMcGithubFaceClient.cs
@@ -5,10 +5,10 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace Fritz.StreamTools.Services
 {
-	public class GitHubClient
+	public class GithubyMcGithubFaceClient
 	{
 
-		public GitHubClient(IHubContext<GithubyMcGithubFace> mcGitHubContext)
+		public GithubyMcGithubFaceClient(IHubContext<GithubyMcGithubFace> mcGitHubContext)
 		{
 
 			this.McGitHubContext = mcGitHubContext;

--- a/Fritz.StreamTools/Startup.cs
+++ b/Fritz.StreamTools/Startup.cs
@@ -1,25 +1,29 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Fritz.StreamTools.Hubs;
-using Fritz.StreamTools.Models;
-using Fritz.StreamTools.Services;
 using Fritz.Twitch;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace Fritz.StreamTools
 {
 	public class Startup
 	{
-		public Startup(IConfiguration configuration)
+		public Startup(IHostingEnvironment env)
 		{
-			Configuration = configuration;
+			var builder = new ConfigurationBuilder();
+			builder
+				.SetBasePath(env.ContentRootPath)
+				.AddJsonFile("appsettings.json", optional: false, reloadOnChange:true)
+				.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional:true, reloadOnChange:true)
+				.AddEnvironmentVariables();
+
+			if (env.IsDevelopment())
+			{
+				builder.AddUserSecrets<Startup>();
+			}
+
+			Configuration = builder.Build();
 		}
 
 		public IConfiguration Configuration { get; }
@@ -35,7 +39,7 @@ namespace Fritz.StreamTools
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-		public void Configure(IApplicationBuilder app, Microsoft.Extensions.Hosting.IHostingEnvironment env)
+		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 		{
 			if (env.IsDevelopment())
 			{

--- a/Fritz.StreamTools/Startup.cs
+++ b/Fritz.StreamTools/Startup.cs
@@ -1,29 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Fritz.StreamTools.Hubs;
+using Fritz.StreamTools.Models;
+using Fritz.StreamTools.Services;
 using Fritz.Twitch;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Fritz.StreamTools
 {
 	public class Startup
 	{
-		public Startup(IHostingEnvironment env)
+		public Startup(IConfiguration configuration)
 		{
-			var builder = new ConfigurationBuilder();
-			builder
-				.SetBasePath(env.ContentRootPath)
-				.AddJsonFile("appsettings.json", optional: false, reloadOnChange:true)
-				.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional:true, reloadOnChange:true)
-				.AddEnvironmentVariables();
-
-			if (env.IsDevelopment())
-			{
-				builder.AddUserSecrets<Startup>();
-			}
-
-			Configuration = builder.Build();
+			Configuration = configuration;
 		}
 
 		public IConfiguration Configuration { get; }
@@ -39,7 +35,7 @@ namespace Fritz.StreamTools
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-		public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+		public void Configure(IApplicationBuilder app, Microsoft.Extensions.Hosting.IHostingEnvironment env)
 		{
 			if (env.IsDevelopment())
 			{

--- a/Fritz.StreamTools/StartupServices/ConfigureServices.cs
+++ b/Fritz.StreamTools/StartupServices/ConfigureServices.cs
@@ -52,9 +52,9 @@ namespace Fritz.StreamTools.StartupServices
 		private static void RegisterGitHubServices(IServiceCollection services, IConfiguration configuration)
 		{
 			services.AddSingleton<GitHubRepository>();
-			services.AddSingleton<Services.GitHubClient>();
+			services.AddSingleton<GithubyMcGithubFaceClient>();
 
-			services.AddTransient(_ => new Octokit.GitHubClient(new ProductHeaderValue("Fritz.StreamTools"))
+			services.AddTransient(_ => new GitHubClient(new ProductHeaderValue("Fritz.StreamTools"))
 			{
 				Credentials = new Credentials(Configuration["GitHub:User"], Configuration["GitHub:AuthenticationToken"])
 			});

--- a/Fritz.StreamTools/StartupServices/ConfigureServices.cs
+++ b/Fritz.StreamTools/StartupServices/ConfigureServices.cs
@@ -51,13 +51,12 @@ namespace Fritz.StreamTools.StartupServices
 
 		private static void RegisterGitHubServices(IServiceCollection services, IConfiguration configuration)
 		{
-			services.AddScoped<GitHubRepository>();
+			services.AddSingleton<GitHubRepository>();
 			services.AddSingleton<Services.GitHubClient>();
 
-			services.AddScoped(_ => {
-				var client = new Octokit.GitHubClient(new ProductHeaderValue("Fritz.StreamTools"));
-				client.Credentials = new Credentials(Configuration["GitHub:User"], Configuration["GitHub:AuthenticationToken"]);
-				return client;
+			services.AddTransient(_ => new Octokit.GitHubClient(new ProductHeaderValue("Fritz.StreamTools"))
+			{
+				Credentials = new Credentials(Configuration["GitHub:User"], Configuration["GitHub:AuthenticationToken"])
 			});
 
 			services.AddHttpClient("GitHub", c =>
@@ -66,11 +65,7 @@ namespace Fritz.StreamTools.StartupServices
 				c.DefaultRequestHeaders.Add("Accept", "applications/json");
 			});
 
-			var provider = services.BuildServiceProvider();
-			var svc = new GitHubService(provider, provider.GetService<ILogger<GitHubService>>());
-			services.AddSingleton(svc as IHostedService);
-			services.AddSingleton(svc);
-
+			services.AddHostedService<GitHubService>();
 		}
 
 		private static void AddStreamingServices(this IServiceCollection services,


### PR DESCRIPTION
Fixes #130 

The idea is as follows. Since there should be only one GithubRepository (and thus only one IAppCache) in the whole application, we want to register it as a singleton. The GithubService should then use that same single repository, but since it's an IHostedService running in a different lifetime scope, it needs to create a scope itself in order to get the same instance of the repository as the GithubController. If not, it would create a singleton of its own (remember that a  hostedservice lives in another lifetime management space). In that case (the unfixed one) we would have 2 repositories, one that the service keeps up to date and the other one being used by the controller, which would keep reading its own old cache, only invalidating after an hour.

Since the repository is now being created as a singleton, the Octokit.GithubClient (a dependency of the repository) can also no longer be scoped and should registered as transient (the preferred way). Only one repo, thus only one Octokit.GithubClient. I refactored out the actual fetching of Contributers from the IAppCache call as those are different concerns. We may want to bypass the app at some point.

Furthermore the GithubService should not be injected into the hub, but use a scoped client to our hub to send the update. The hub instance lives in the webapp space and thus cannot use the instance of GithubService which lives in the hostedservice space. So instead of using an instance of githubservice itself and hooking up its event, we let the githubservice use the scoped client to the hub to send out the update. We have a client to that hub, but it was conveniently also named GitHubClient, so I renamed the existing client to avoid confusion with the octokit.githubclient to GithubyMcGithubFaceClient. (conform with the name of the hub).

I also added support for UserSecrets in Startup. Although not part of the issue to fix, it made debugging a bit easier.