### PR TITLE
Fix/fix chatbot unittest

### DIFF
--- a/Test/Chatbot/WhenChatMessageSent.cs
+++ b/Test/Chatbot/WhenChatMessageSent.cs
@@ -145,7 +145,7 @@ namespace Test.Chatbot
 			_chatservice.Raise(cs => cs.ChatMessage += null, args);
 			_chatservice.Verify(sm => sm.SendMessageAsync(
 						It.Is<string>(x => x.StartsWith($"{command}: {description}"))),
-						Times.AtLeastOnce);
+						Times.Once);
 		}
 
 		[Fact]
@@ -197,7 +197,7 @@ namespace Test.Chatbot
 
 			_chatservice.Verify(sm => sm.SendMessageAsync(
 						It.Is<string>(x => x.StartsWith("Supported commands:"))),
-						Times.Exactly(1));
+						Times.Once);
 		}
 
 		[Fact]
@@ -217,7 +217,7 @@ namespace Test.Chatbot
 			_chatservice.Raise(cs => cs.ChatMessage += null, args);
 			_chatservice.Verify(sm => sm.SendMessageAsync(
 							It.Is<string>(x => x.StartsWith("testusername's linked page title:"))),
-							Times.Exactly(1));
+							Times.Once);
 		}
 
 		[Fact]


### PR DESCRIPTION
Reffering to #140

To fix that test,  it was necessary to change the register commands in the constructor.  
I have not used reflection to load all commands because the test should be written in an easy and transparent way in my opinion (but if you prefer i can change it).

Little fixes:
- sort usings,
- remove redundant empty lines,
- fix code formeting
- change in tests Times.Exactly(1) -> Times.Once it do same but i think it's more clear notation.

Future info:
It's bad have all test of ChatBot Commands in one UnitTest, because that register all commands to test one it begins to look complex (it's shoudn't, it's UnitTest!!), if we will have more and more commands will be difficult to easy test it. In my opinion we should split every command to separate UnitTest file etc. 

But these are only my thoughts, if you agree, you can start a new issue with an idea how to organize it, 
if it's a bad idea, reject my suggestions.

Regards