### PR TITLE
Enable both config for test ShouldIgnoreCommandsToFastIfModerator

### DIFF
--- a/Test/Chatbot/WhenChatMessageSent.cs
+++ b/Test/Chatbot/WhenChatMessageSent.cs
@@ -195,15 +195,15 @@ namespace Test.Chatbot
 			_chatservice.Raise(cs => cs.ChatMessage += null, args);
 			_chatservice.Raise(cs => cs.ChatMessage += null, args);
 			
-			var times = Moq.Times.Once();
+			var verifyTimes = Moq.Times.Once();
 
 #if !DEBUG
-			times = Moq.Times.Exactly(2);
+			verifyTimes = Moq.Times.Exactly(2);
 #endif
 
 	  	_chatservice.Verify(sm => sm.SendMessageAsync(
-							It.Is<string>(x => x.StartsWith("Supported commands:"))),
-							times);
+					It.Is<string>(x => x.StartsWith("Supported commands:"))),
+					verifyTimes);
 		}
 
 		[Fact]

--- a/Test/Chatbot/WhenChatMessageSent.cs
+++ b/Test/Chatbot/WhenChatMessageSent.cs
@@ -194,10 +194,16 @@ namespace Test.Chatbot
 
 			_chatservice.Raise(cs => cs.ChatMessage += null, args);
 			_chatservice.Raise(cs => cs.ChatMessage += null, args);
+			
+			var times = Moq.Times.Once();
 
-			_chatservice.Verify(sm => sm.SendMessageAsync(
-						It.Is<string>(x => x.StartsWith("Supported commands:"))),
-						Times.Once);
+#if !DEBUG
+			times = Moq.Times.Exactly(2);
+#endif
+
+	  	_chatservice.Verify(sm => sm.SendMessageAsync(
+							It.Is<string>(x => x.StartsWith("Supported commands:"))),
+							times);
 		}
 
 		[Fact]


### PR DESCRIPTION
I noticed that one of the tests (**ShouldIgnoreCommandsToFastIfModerator**) was failing depending on whether it was Debug vs. Release config. Here's an update to the test code to add the !DEBUG condition and verify parameter to match the actual code. 

Tested this fix locally and using Azure Pipelines. 

Note: Switching configs within Visual Studio IDE requires a re-start and appears to be impacted by https://github.com/dotnet/project-system/issues/2733