### PR TITLE
Docker: use microsoft/dotnet:2.1.401-sdk

### DIFF
--- a/Fritz.StreamTools/Dockerfile
+++ b/Fritz.StreamTools/Dockerfile
@@ -2,7 +2,7 @@ FROM microsoft/dotnet:2.1-aspnetcore-runtime AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM microsoft/dotnet:2.1.401-sdk AS build
 WORKDIR /src
 COPY global.json .
 COPY Fritz.StreamTools/Fritz.StreamTools.csproj Fritz.StreamTools/


### PR DESCRIPTION
The checked-in `global.json` pins the SDK version to 2.1.401.  Use the matching container for compatibility.