### PR TITLE
Fixed a few issues with the Follower UI & FollowerCountConfiguration.LoadDefaultSettings method

### DIFF
--- a/Fritz.StreamTools/Controllers/FollowersController.cs
+++ b/Fritz.StreamTools/Controllers/FollowersController.cs
@@ -81,16 +81,12 @@ namespace Fritz.StreamTools.Controllers
 				return View("Docs_Count");
 			}
 
-			// TODO: Read this from AppSettings?
 			model.LoadDefaultSettings(CountConfiguration);
 
-				if (model.CurrentValue == 0)
-				{
-					model.CurrentValue = StreamService.CurrentFollowerCount;
-				}
-
-
-
+			if (model.CurrentValue == 0)
+			{
+				model.CurrentValue = StreamService.CurrentFollowerCount;
+			}
 
 			return View(model);
 

--- a/Fritz.StreamTools/Controllers/FollowersController.cs
+++ b/Fritz.StreamTools/Controllers/FollowersController.cs
@@ -93,9 +93,10 @@ namespace Fritz.StreamTools.Controllers
 		}
 
 		[Route("followers/count/configuration", Name ="ConfigurationFollowerCount")]
-		public IActionResult CountConfigurationAction()
+		public IActionResult CountConfigurationAction(FollowerCountConfiguration model)
 		{
-			return View("CountConfiguration");
+			model.LoadDefaultSettings(CountConfiguration);
+			return View("CountConfiguration", model);
 		}
 
 		[Route("followers/goal/{*stuff}")]

--- a/Fritz.StreamTools/Models/FollowerCountConfiguration.cs
+++ b/Fritz.StreamTools/Models/FollowerCountConfiguration.cs
@@ -16,9 +16,8 @@ namespace Fritz.StreamTools.Models
 
 		internal void LoadDefaultSettings(FollowerCountConfiguration config)
 		{
-			this.BackgroundColor = string.IsNullOrWhiteSpace(this.BackgroundColor) ? config.BackgroundColor : "#000";
-			this.FontColor = string.IsNullOrWhiteSpace(this.FontColor) ? config.FontColor : "#32cd32";
-
+			this.BackgroundColor = string.IsNullOrWhiteSpace(this.BackgroundColor) ? config.BackgroundColor : this.BackgroundColor;
+			this.FontColor = string.IsNullOrWhiteSpace(this.FontColor) ? config.FontColor : this.FontColor;
 		}
 
 	}

--- a/Fritz.StreamTools/Views/Followers/CountConfiguration.cshtml
+++ b/Fritz.StreamTools/Views/Followers/CountConfiguration.cshtml
@@ -22,7 +22,7 @@
 	<div class="col-md-6 mb-3 form-inline">
 		<label asp-for="BackgroundColor"></label>
 		&nbsp;
-		<input type="color" asp-for="BackgroundColor" value="#CCCCCC" />
+		<input type="color" asp-for="BackgroundColor" value="@nameof(Model.FontColor)" />
 	</div>
 </div>
 
@@ -54,17 +54,15 @@
 			FontColor: "@nameof(Model.FontColor)"
 		};
 
-        var log = function (message, params) {
-            @if (HostingEnvironment.IsDevelopment())
-	{
-<text>console.log(message, params);</text>
-}
-        };
+    var log = function (message, params) {
+        @if (HostingEnvironment.IsDevelopment())
+				{
+					<text>console.log(message, params);</text>
+				}
+    };
 
-		(function () {
-
-	    //document.getElementById('fontsPanel').style.display = 'none';
-
+		(
+			function () {
 	        loadPreview();
 
 	        InitPreview();
@@ -83,33 +81,25 @@
 			}
 
 			document.getElementById(quickPreviewButton).onclick = loadPreview;
+		}
+
+		function loadPreview() {
+
+			const iframeWidth = document.getElementById("widgetPreview").clientWidth - 40;
+
+			var urlTemplate = "/followers/count?";
+			urlTemplate += `${ConfigurationModel.BackgroundColor}=${escape(document.getElementById(ConfigurationModel.BackgroundColor).value)}`;
+			urlTemplate += `&${ConfigurationModel.FontColor}=${escape(document.getElementById(ConfigurationModel.FontColor).value)}`;
+			//urlTemplate += `&fontName=${escape(fontName)}`;
+
+			document.getElementById("widgetPreview").src = urlTemplate + `&${ConfigurationModel.CurrentValue}=${document.getElementById(ConfigurationModel.CurrentValue).value}`
+			log(urlTemplate);
+
+			document.getElementById("outputUrl").textContent = urlTemplate;
+			document.getElementById("outputUrl").href = urlTemplate;
+			//saveValues();
 
 		}
 
-
-function loadPreview() {
-
-	const iframeWidth = document.getElementById("widgetPreview").clientWidth - 40;
-
-
-	var urlTemplate = "/followers/count?";
-	urlTemplate += `${ConfigurationModel.BackgroundColor}=${escape(document.getElementById(ConfigurationModel.BackgroundColor).value)}`;
-	urlTemplate += `&${ConfigurationModel.FontColor}=${escape(document.getElementById(ConfigurationModel.FontColor).value)}`;
-	//urlTemplate += `&fontName=${escape(fontName)}`;
-
-	document.getElementById("widgetPreview").src = urlTemplate + `&${ConfigurationModel.CurrentValue}=${document.getElementById(ConfigurationModel.CurrentValue).value}`
-	log(urlTemplate);
-
-	document.getElementById("outputUrl").textContent = urlTemplate;
-	document.getElementById("outputUrl").href = urlTemplate;
-	//saveValues();
-
-}
-
-
-
-
-
 </script>
-
 }


### PR DESCRIPTION
Found and cleaned up a couple issues when trying to setup for my stream.  They were:

- The `followers/count` route only displayed hard-coded colors for the background and font color despite the model having values passed via a querystring.  The LoadDefaultSettings should now display the values from the app.settings if no value is provided for the background or font colors.  Otherwise, it will display the provided colors.
- Improved the configuration UI to display the colors specified in app.settings by default rather than a hard-coded `#cccccc`.
- Made a few formatting changes because I'm a little anal.