### PR TITLE
Add a space between repetitions in Hype command

### DIFF
--- a/Fritz.Chatbot/Commands/HypeCommand.cs
+++ b/Fritz.Chatbot/Commands/HypeCommand.cs
@@ -38,6 +38,10 @@ namespace Fritz.Chatbot.Commands
 
 			var sb = new StringBuilder();
 			for (var i=0; i<repeatCount; i++) {
+				if (i!=0)
+				{
+					sb.Append(" ");
+				}
 				sb.Append(hypeText);
 			}
 


### PR DESCRIPTION
The Hype command currently misses a space between internal repetitions of the string. This fixes that.