### PR TITLE
Fix some unit test configuration

### DIFF
--- a/Test/Chatbot/ChatBotTests.cs
+++ b/Test/Chatbot/ChatBotTests.cs
@@ -31,6 +31,7 @@ namespace Test.Chatbot
 			_config = new Mock<IConfiguration>();
 			_chatservice = new Mock<IChatService>();
 			_chatservice.SetupGet(x => x.IsAuthenticated).Returns(true);
+			_chatservice.SetupGet(s => s.BotUserName).Returns("MockedChatSerivce");
 
 			var chatServices = new List<IChatService> { _chatservice.Object };
 			_serviceProvider = new Mock<IServiceProvider>();

--- a/Test/Chatbot/WhenChatMessageSent.cs
+++ b/Test/Chatbot/WhenChatMessageSent.cs
@@ -29,6 +29,7 @@ namespace Test.Chatbot
 			_config = new Mock<IConfiguration>();
 			_config.SetupGet(s => s[FritzBot.ConfigurationRoot + ":CooldownTime"]).Returns("1");
 			_chatservice = new Mock<IChatService>();
+			_chatservice.SetupGet(s => s.BotUserName).Returns("MockedChatSerivce");
 			_chatservice.SetupGet(x => x.IsAuthenticated).Returns(true);
 
 			var chatServices = new List<IChatService> { _chatservice.Object };


### PR DESCRIPTION
Small commit, just fix some unit test configuration but there are still 2 units which not working.

- Test for Final command, [this change](https://github.com/csharpfritz/Fritz.StreamTools/commit/37c6f23c5ecb652719fca75ef2100ef2ea67556b#diff-371d74b9132b6d8f72400a87b70ca341L216) , i don't get why we do that probably i missed it on stream (also ask about it on chat last time), after that change HandleExtendedCommands will always return false (it's really correct approach?)
- ConfigureServicesTests - i will fix it with #247 