### PR TITLE
Add !livecoders command to FritzBot

### DIFF
--- a/Fritz.StreamTools/appsettings.json
+++ b/Fritz.StreamTools/appsettings.json
@@ -82,6 +82,10 @@
 				"response": "Jeff uses a Vortex Race 3 with Cherry MX Blue switches, details on his blog at: https://jeffreyfritz.com/2018/07/mechanical-keyboards-i-just-got-one-and-why-you-need-one-too/"
 			},
 			{
+				"command": "livecoders",
+				"response": "The LiveCoders team is an outgoing and enthusiastic group of friendly channels that write code, teach about technology, and promote the technical community. Check them out at https://livecoders.dev"
+			},
+			{
 				"command": "lurk",
 				"response": "is stepping away from keyboard and lurking"
 			},


### PR DESCRIPTION
I felt it would be useful to have a text command to link to the Live Coders team.